### PR TITLE
security: harden URL, SIWE, recovery, and logging surfaces

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this SDK, please report it privately.
+
+**Please do not open a public GitHub issue for security reports.**
+
+- Email: **security@openfort.xyz**
+- Encrypted / signed reports are welcome.
+
+We will acknowledge receipt within **3 business days** and aim to provide an initial triage within **7 business days**. Once a fix is available, we coordinate a disclosure timeline with the reporter before publishing.
+
+When reporting, please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, a proof-of-concept, or a failing test.
+- The affected SDK version (`pnpm list @openfort/openfort-react`), browser/runtime, and any relevant config.
+- Whether the issue is already public and, if so, where.
+
+## Supported Versions
+
+Security fixes are published for the **latest minor release** of `@openfort/openfort-react`. Older releases are supported on a best-effort basis.
+
+| Version       | Supported |
+| ------------- | --------- |
+| Latest minor  | ✅        |
+| Older minors  | ⚠️ best-effort |
+| Pre-release   | ❌        |
+
+## Scope
+
+The following are in scope:
+
+- Code under `packages/openfort-react/`.
+- The SDK's public API surface, storage handling, URL handling, signing flows, and OAuth callback handling.
+- Dependency vulnerabilities that are reachable via default SDK usage.
+
+Out of scope:
+
+- Issues requiring a user to install a malicious browser extension.
+- Issues in third-party wallets, RPC providers, or services the SDK integrates with — please report those to the vendor.
+- Denial-of-service against the consuming application that does not involve SDK-level exploitation.
+
+## Security Best Practices for Integrators
+
+- Always configure an explicit `chainId`; do not rely on defaults.
+- Use the built-in `safeExternalHref` / `safeImageSrc` helpers (`utils/urlSecurity`) when rendering user-influenced URLs.
+- Host the `createEncryptedSessionEndpoint` on HTTPS; the SDK rejects non-`http(s):` endpoints.
+- Keep `@openfort/openfort-react` pinned to the latest patch release to receive security fixes.

--- a/packages/openfort-react/src/__tests__/utils/createSiweMessage.test.ts
+++ b/packages/openfort-react/src/__tests__/utils/createSiweMessage.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { createSIWEMessage } from '../../siwe/create-siwe-message'
+
+const ADDRESS = '0x1234567890abcdef1234567890abcdef12345678' as `0x${string}`
+const VALID_NONCE = 'abc123XYZ456'
+
+describe('createSIWEMessage', () => {
+  it('builds a SIWE message with valid inputs', () => {
+    const msg = createSIWEMessage(ADDRESS, VALID_NONCE, 1)
+    expect(msg).toBeDefined()
+    expect(msg).toContain(VALID_NONCE)
+    expect(msg).toContain('Chain ID: 1')
+    expect(msg).toContain('Issued At:')
+    expect(msg).toContain('Expiration Time:')
+  })
+
+  it.each([0, -1, 1.5, Number.NaN])('throws on invalid chainId %s', (chainId) => {
+    expect(() => createSIWEMessage(ADDRESS, VALID_NONCE, chainId)).toThrow(/chainId/i)
+  })
+
+  it.each([
+    '',
+    'short',
+    'with spaces',
+    'nonce!@#',
+    'a'.repeat(200),
+    123 as unknown as string,
+  ])('throws on malformed nonce %s', (nonce) => {
+    expect(() => createSIWEMessage(ADDRESS, nonce as string, 1)).toThrow(/nonce/i)
+  })
+
+  it('produces an expirationTime within 10 minutes of issuedAt', () => {
+    const msg = createSIWEMessage(ADDRESS, VALID_NONCE, 1) as string
+    const issuedMatch = msg.match(/Issued At: (.+)/)
+    const expiryMatch = msg.match(/Expiration Time: (.+)/)
+    expect(issuedMatch?.[1]).toBeDefined()
+    expect(expiryMatch?.[1]).toBeDefined()
+    const diff = new Date(expiryMatch?.[1] ?? '').getTime() - new Date(issuedMatch?.[1] ?? '').getTime()
+    expect(diff).toBe(10 * 60 * 1000)
+  })
+})

--- a/packages/openfort-react/src/__tests__/utils/urlSecurity.test.ts
+++ b/packages/openfort-react/src/__tests__/utils/urlSecurity.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { safeExternalHref, safeImageSrc } from '../../utils/urlSecurity'
+
+describe('safeExternalHref', () => {
+  it.each([
+    ['https://example.com', true],
+    ['http://example.com/path?q=1', true],
+    ['mailto:user@example.com', true],
+    ['/relative/path', true],
+  ])('accepts %s', (url, _accepted) => {
+    expect(safeExternalHref(url)).toBeDefined()
+  })
+
+  it.each([
+    ['javascript:alert(1)'],
+    ['JavaScript:alert(1)'],
+    ['  javascript:alert(1)'],
+    ['data:text/html,<script>alert(1)</script>'],
+    ['vbscript:msgbox(1)'],
+    ['file:///etc/passwd'],
+    [''],
+    [null as unknown as string],
+    [undefined as unknown as string],
+    [{} as unknown as string],
+  ])('rejects %s', (url) => {
+    expect(safeExternalHref(url)).toBeUndefined()
+  })
+})
+
+describe('safeImageSrc', () => {
+  it('accepts http(s) image URLs', () => {
+    expect(safeImageSrc('https://cdn.example.com/a.png')).toBeDefined()
+  })
+
+  it('accepts whitelisted data:image base64 URLs', () => {
+    const png =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX///+nxBvIAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=='
+    expect(safeImageSrc(png)).toBe(png)
+  })
+
+  it('rejects javascript: scheme', () => {
+    expect(safeImageSrc('javascript:alert(1)')).toBeUndefined()
+  })
+
+  it('rejects non-image data: URLs', () => {
+    expect(safeImageSrc('data:text/html;base64,PHNjcmlwdD4=')).toBeUndefined()
+  })
+})

--- a/packages/openfort-react/src/components/Common/Avatar/index.tsx
+++ b/packages/openfort-react/src/components/Common/Avatar/index.tsx
@@ -6,6 +6,7 @@ import { useConnectionStrategy } from '../../../core/ConnectionStrategyContext'
 import { useEthereumBridge } from '../../../ethereum/OpenfortEthereumBridgeContext'
 import useIsMounted from '../../../hooks/useIsMounted'
 import { ResetContainer } from '../../../styles'
+import { safeImageSrc } from '../../../utils/urlSecurity'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { EnsAvatar, ImageContainer } from './styles'
 
@@ -114,7 +115,11 @@ const Avatar: React.FC<{
       </div>
     )
 
-  if (!ens.name || !ens.avatar)
+  // Validate the ENS avatar URL scheme. Malicious ENS records can point to
+  // `javascript:` / non-image `data:` URIs; `safeImageSrc` whitelists
+  // `http(s):` and `data:image/*;base64` sources only.
+  const safeAvatar = safeImageSrc(ens.avatar)
+  if (!ens.name || !safeAvatar)
     return (
       <ResetContainer style={{ pointerEvents: 'none' }}>
         <EnsAvatar $size={size} $seed={ens.address} $radius={radius} />
@@ -125,7 +130,7 @@ const Avatar: React.FC<{
       <EnsAvatar $size={size} $seed={ens.address} $radius={radius}>
         <ImageContainer
           ref={imageRef}
-          src={ens.avatar}
+          src={safeAvatar}
           alt={ens.name}
           onLoad={() => setLoaded(true)}
           $loaded={loaded}

--- a/packages/openfort-react/src/components/Common/Button/index.tsx
+++ b/packages/openfort-react/src/components/Common/Button/index.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence } from 'framer-motion'
 import type React from 'react'
 import { flattenChildren } from '../../../utils'
+import { safeExternalHref } from '../../../utils/urlSecurity'
 import FitText from '../FitText'
 import { Spinner } from '../Spinner'
 import {
@@ -44,18 +45,22 @@ const Button: React.FC<ButtonProps> = ({
   const key = typeof children === 'string' ? children : flattenChildren(children).join('') // Need to generate a string for the key so we can automatically animate between content
 
   const hrefUrl = href && (typeof href === 'string' ? href : flattenChildren(href).join('')) // Need to have a flat string for the href
+  // Reject `javascript:`, `data:`, and other script-bearing schemes so that
+  // a mis-configured SDK option or connector metadata entry cannot escalate
+  // to XSS through an anchor `href`.
+  const safeHref = safeExternalHref(hrefUrl || undefined)
 
   return (
     <ButtonContainer
       className={className}
-      as={href ? 'a' : type ? 'button' : undefined}
+      as={safeHref ? 'a' : type ? 'button' : undefined}
       type={type}
       onClick={(event: any) => {
         if (!disabled && onClick) onClick(event)
       }}
-      href={href && hrefUrl}
-      target={href && '_blank'}
-      rel={href && 'noopener noreferrer'}
+      href={safeHref}
+      target={safeHref && '_blank'}
+      rel={safeHref && 'noopener noreferrer'}
       disabled={disabled}
       $variant={variant}
       style={style}

--- a/packages/openfort-react/src/shared/utils/recovery.ts
+++ b/packages/openfort-react/src/shared/utils/recovery.ts
@@ -91,34 +91,78 @@ async function getEncryptionSession(params: {
   }
 
   if (walletConfig.createEncryptedSessionEndpoint) {
-    const response = await fetch(walletConfig.createEncryptedSessionEndpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ user_id: userId, otp_code: otpCode }),
-    })
+    // Reject non-http(s) endpoints up front. A misconfigured
+    // `createEncryptedSessionEndpoint` (e.g. a stringified object or a
+    // `javascript:` URL) should fail loudly rather than become a network
+    // request to the current origin.
+    let endpointUrl: URL
+    try {
+      endpointUrl = new URL(walletConfig.createEncryptedSessionEndpoint)
+    } catch {
+      throw new OpenfortError(
+        'createEncryptedSessionEndpoint is not a valid URL',
+        OpenfortReactErrorType.CONFIGURATION_ERROR
+      )
+    }
+    if (endpointUrl.protocol !== 'https:' && endpointUrl.protocol !== 'http:') {
+      throw new OpenfortError(
+        'createEncryptedSessionEndpoint must use http(s)',
+        OpenfortReactErrorType.CONFIGURATION_ERROR
+      )
+    }
+
+    // Bound the request so a stalled server cannot hang recovery UI.
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 30_000)
+
+    let response: Response
+    try {
+      response = await fetch(endpointUrl.toString(), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: userId, otp_code: otpCode }),
+        signal: controller.signal,
+        credentials: 'omit',
+      })
+    } catch (err) {
+      throw new OpenfortError('Failed to reach encryption session endpoint', OpenfortReactErrorType.WALLET_ERROR, {
+        cause: err instanceof Error ? err : new Error(String(err)),
+      })
+    } finally {
+      clearTimeout(timeout)
+    }
 
     type SessionResponse = { error?: string; message?: string; session?: string }
-    let data: SessionResponse
-    try {
-      data = (await response.json()) as SessionResponse
-    } catch {
-      data = {}
+    const contentType = response.headers.get('content-type') ?? ''
+    // Reject explicit non-JSON content types (e.g. text/html) to avoid
+    // swallowing a captured-portal / misrouted response, but stay permissive
+    // when the header is missing since many dev servers omit it.
+    let data: SessionResponse = {}
+    const isJsonish =
+      contentType === '' || contentType.includes('application/json') || contentType.includes('text/plain')
+    if (isJsonish) {
+      try {
+        data = (await response.json()) as SessionResponse
+      } catch {
+        data = {}
+      }
     }
     if (!response.ok) {
       if (data.error === 'OTP_REQUIRED') {
         throw new OpenfortError('OTP verification required', OpenfortReactErrorType.AUTHENTICATION_ERROR)
       }
-      const errMsg =
-        typeof (data.error ?? data.message) === 'string'
-          ? `Failed to create encryption session: ${data.error ?? data.message}`
-          : 'Failed to create encryption session'
-      throw new OpenfortError(errMsg, OpenfortReactErrorType.WALLET_ERROR, {
-        error: data.error != null ? new Error(String(data.error)) : undefined,
+      // Never interpolate server-returned strings into the user-visible
+      // message — keep them in `cause` for diagnostics only. Prevents a
+      // compromised or misbehaving backend from shaping the SDK's error
+      // surface with arbitrary text.
+      throw new OpenfortError('Failed to create encryption session', OpenfortReactErrorType.WALLET_ERROR, {
+        status: response.status,
+        cause: (data.error ?? data.message) ? new Error(String(data.error ?? data.message)) : undefined,
       })
     }
 
     const session = data.session
-    if (typeof session !== 'string' || session.length === 0) {
+    if (typeof session !== 'string' || session.length === 0 || session.length > 8192) {
       throw new OpenfortError('Invalid encryption session response', OpenfortReactErrorType.WALLET_ERROR)
     }
     return session

--- a/packages/openfort-react/src/siwe/create-siwe-message.ts
+++ b/packages/openfort-react/src/siwe/create-siwe-message.ts
@@ -1,12 +1,19 @@
 import { createSiweMessage } from 'viem/siwe'
 
+const NONCE_RE = /^[A-Za-z0-9_-]{8,128}$/
+const SIWE_EXPIRATION_MS = 10 * 60 * 1000 // 10 minutes
+
 /**
  * Creates a SIWE message for wallet auth. Uses current domain and origin.
  * Safe for SSR: returns undefined when window is not available.
  *
+ * Hardened against replay by requiring a non-zero chainId and by pinning
+ * `issuedAt` / `expirationTime` on the signed payload, even when the
+ * backend nonce-store would otherwise catch a replay.
+ *
  * @param address - Wallet address to sign
- * @param nonce - Server-provided nonce
- * @param chainId - Chain ID for the message
+ * @param nonce - Server-provided nonce (must match `[A-Za-z0-9_-]{8,128}`)
+ * @param chainId - Chain ID for the message (must be > 0)
  *
  * @example
  * ```tsx
@@ -16,6 +23,14 @@ import { createSiweMessage } from 'viem/siwe'
  */
 export const createSIWEMessage = (address: `0x${string}`, nonce: string, chainId: number) => {
   if (typeof window === 'undefined') return undefined
+  if (!Number.isInteger(chainId) || chainId <= 0) {
+    throw new Error(`Invalid chainId for SIWE message: ${chainId}`)
+  }
+  if (typeof nonce !== 'string' || !NONCE_RE.test(nonce)) {
+    throw new Error('Invalid SIWE nonce format')
+  }
+  const issuedAt = new Date()
+  const expirationTime = new Date(issuedAt.getTime() + SIWE_EXPIRATION_MS)
   return createSiweMessage({
     domain: window.location.host,
     address,
@@ -23,7 +38,9 @@ export const createSIWEMessage = (address: `0x${string}`, nonce: string, chainId
       'By signing, you are proving you own this wallet and logging in. This does not initiate a transaction or cost any fees.',
     uri: window.location.origin,
     version: '1',
-    chainId: chainId,
+    chainId,
     nonce,
+    issuedAt,
+    expirationTime,
   })
 }

--- a/packages/openfort-react/src/utils/logger.ts
+++ b/packages/openfort-react/src/utils/logger.ts
@@ -1,11 +1,19 @@
 const PREFIX = '[Openfort-React]'
 
+/**
+ * SDK logger.
+ *
+ * `log` and `warn` are gated behind `enabled` to keep the console clean in
+ * production. `error` always emits — silently swallowing errors in the
+ * field makes real outages undebuggable and encourages blind `.catch(() => {})`
+ * patterns that mask auth/recovery failures.
+ */
 export const logger = {
   enabled: false,
   // biome-ignore lint/suspicious/noConsole: allowed for debugging
   log: (...args: any[]) => (logger.enabled ? console.log(PREFIX, ...args) : null),
-  // biome-ignore lint/suspicious/noConsole: allowed for debugging
-  error: (...args: any[]) => (logger.enabled ? console.error(PREFIX, ...args) : null),
+  // biome-ignore lint/suspicious/noConsole: errors always surface for diagnostics
+  error: (...args: any[]) => console.error(PREFIX, ...args),
   // biome-ignore lint/suspicious/noConsole: allowed for debugging
   warn: (...args: any[]) => (logger.enabled ? console.warn(PREFIX, ...args) : null),
 }

--- a/packages/openfort-react/src/utils/urlSecurity.ts
+++ b/packages/openfort-react/src/utils/urlSecurity.ts
@@ -35,6 +35,55 @@ export function suppressReferrer(): () => void {
   }
 }
 
+const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:'])
+
+/**
+ * Returns the URL if it uses a safe protocol (`http:`, `https:`, `mailto:`),
+ * otherwise returns `undefined`.
+ *
+ * Use for any `href`/`src` attribute that takes a URL from untrusted
+ * sources (SDK config, connector metadata, ENS records, server responses).
+ * Blocks `javascript:`, `data:`, `vbscript:`, `file:` and other
+ * script-bearing schemes that can escalate to XSS.
+ *
+ * Relative URLs are resolved against `window.location.origin` and
+ * allowed as `http(s):`.
+ *
+ * @example
+ * ```tsx
+ * <a href={safeExternalHref(userProvidedUrl)} target="_blank" rel="noopener noreferrer" />
+ * ```
+ */
+export function safeExternalHref(url: string | null | undefined): string | undefined {
+  if (!url || typeof url !== 'string') return undefined
+  try {
+    const base = typeof window !== 'undefined' ? window.location.origin : 'https://localhost'
+    const u = new URL(url, base)
+    return SAFE_PROTOCOLS.has(u.protocol) ? u.toString() : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const IMG_DATA_URL_RE = /^data:image\/(?:png|jpeg|jpg|gif|webp|svg\+xml);base64,/i
+
+/**
+ * Returns the URL if it is a safe image source.
+ *
+ * Accepts `http(s):` and narrowly whitelisted `data:image/...;base64` URLs.
+ * Rejects `javascript:`, raw `data:`, and other schemes. SVG data URLs are
+ * allowed but callers rendering them as `<img>` are safe because the
+ * browser blocks script execution inside `<img src>`.
+ *
+ * Primarily intended for ENS avatars and other user-influenced image
+ * sources where a malicious record could attempt XSS via the `src`.
+ */
+export function safeImageSrc(url: string | null | undefined): string | undefined {
+  if (!url || typeof url !== 'string') return undefined
+  if (IMG_DATA_URL_RE.test(url)) return url
+  return safeExternalHref(url)
+}
+
 /**
  * Parses the current `window.location.href`, fixing the OF-1013 issue
  * where the server redirect produces a URL with a duplicate `?`, e.g.

--- a/packages/openfort-react/src/wagmi/useConnectWithSiwe.ts
+++ b/packages/openfort-react/src/wagmi/useConnectWithSiwe.ts
@@ -54,7 +54,7 @@ export function useConnectWithSiwe() {
       const address = propsAddress ?? b?.account?.address
       const connectorType = propsConnectorType ?? b?.account?.connector?.type
       const walletClientType = propsWalletClientType ?? b?.account?.connector?.id
-      const chainId = b?.chainId ?? 0
+      const chainId = b?.chainId
       const accountChainId = b?.account?.chain?.id ?? b?.chainId
       const chainName = b?.account?.chain?.name
       const switchChainAsync = b?.switchChain?.switchChainAsync
@@ -66,6 +66,16 @@ export function useConnectWithSiwe() {
         return
       }
 
+      // Reject SIWE when chainId is not a positive integer — signing with
+      // chainId=0 / undefined produces a message that can be replayed across
+      // chains that don't enforce the field.
+      if (chainId === undefined || !Number.isInteger(chainId) || chainId <= 0) {
+        logger.warn('[useConnectWithSiwe] Invalid chainId', { chainId })
+        onError?.('No active chain. Connect your wallet to a supported network and try again.')
+        return
+      }
+      const validChainId: number = chainId
+
       if (!signMessage) {
         logger.warn('[useConnectWithSiwe] No signMessage on bridge')
         onError?.('EVM bridge not available (signMessage)')
@@ -73,8 +83,8 @@ export function useConnectWithSiwe() {
       }
 
       try {
-        if (accountChainId !== chainId && switchChainAsync) {
-          await switchChainAsync({ chainId })
+        if (accountChainId !== validChainId && switchChainAsync) {
+          await switchChainAsync({ chainId: validChainId })
         }
 
         let nonce: string
@@ -86,7 +96,7 @@ export function useConnectWithSiwe() {
           nonce = resp.nonce
         }
 
-        const SIWEMessage = createSIWEMessage(address, nonce, chainId)
+        const SIWEMessage = createSIWEMessage(address, nonce, validChainId)
         if (!SIWEMessage) throw new Error('SIWE message creation failed (window not available)')
 
         const signature = await signMessage({ message: SIWEMessage })
@@ -98,7 +108,7 @@ export function useConnectWithSiwe() {
             connectorType,
             walletClientType,
             address,
-            chainId,
+            chainId: validChainId,
           })
         } else {
           await client.auth.loginWithSiwe({


### PR DESCRIPTION
## Summary

Defense-in-depth security hardening across the SDK's external-input surfaces. No breaking changes to the public API.

### URL handling — XSS mitigation
- New `safeExternalHref` / `safeImageSrc` helpers in `utils/urlSecurity` whitelist \`http(s):\` / \`mailto:\` and narrow \`data:image/*;base64\` sources.
- Applied at \`Common/Button\` (covers every Button-rendered link across the SDK — Onboarding, About, PoweredByFooter, ConnectWithInjector, ConnectWithMobile, etc.) and \`Common/Avatar\` for ENS avatars.
- Blocks \`javascript:\`, arbitrary \`data:\`, \`vbscript:\`, \`file:\` and other script-bearing schemes that could be introduced via config, connector metadata, or a malicious ENS record.

### SIWE hardening (\`siwe/create-siwe-message\`, \`wagmi/useConnectWithSiwe\`)
- Rejects \`chainId <= 0\` / non-integer chain IDs — previously \`chainId\` could fall through as \`0\` when no chain was active, producing a message that is cross-chain replayable on any chain that doesn't strictly enforce the field.
- Validates the server-provided nonce against \`[A-Za-z0-9_-]{8,128}\` before signing.
- Pins \`issuedAt\` and \`expirationTime\` (10 min) on the signed payload to bound replay windows defense-in-depth with the backend nonce store.

### Recovery endpoint (\`shared/utils/recovery\`)
- Validates the configured \`createEncryptedSessionEndpoint\` is a real \`http(s):\` URL.
- Adds a 30s \`AbortController\` timeout so a stalled server cannot hang recovery UI indefinitely.
- Sends \`credentials: 'omit'\` — the endpoint is expected to authenticate via the JSON body, not ambient cookies.
- Rejects explicit non-JSON content-types; caps session length at 8 KiB.
- **Stops interpolating server-returned \`error\`/\`message\` strings into the user-visible \`OpenfortError\` message.** Upstream detail moves to \`cause\` / \`status\` for diagnostics only. Prevents a compromised or misbehaving backend from shaping the SDK's user-facing error surface with arbitrary text.

### Logger
- \`logger.error\` now always emits. It was previously gated behind \`enabled: false\`, meaning every \`.catch(err => logger.error(...))\` in the SDK silently dropped errors in production — making real outages effectively undebuggable.
- \`log\` / \`warn\` remain debug-gated.

### Governance
- Adds \`SECURITY.md\` at the repo root with a private disclosure channel (\`security@openfort.xyz\`), supported-versions matrix, scope, and integrator guidance.

## Test plan

- [x] 30 new unit tests (\`urlSecurity.test.ts\` — 18 cases, \`createSiweMessage.test.ts\` — 12 cases) pass locally
- [x] Existing test suite — no new regressions (baseline had 23 pre-existing failing tests unrelated to this change; count does not increase)
- [x] \`pnpm biome check\` clean on all touched files
- [x] \`pnpm exec tsc --noEmit\` — zero source-level type errors
- [ ] Manual smoke test: SIWE flow rejects \`chainId=0\` and shows a user-actionable error
- [ ] Manual smoke test: ENS avatar with a \`data:text/html\` record renders fallback identicon rather than loading the record