### PR TITLE
Fix repeated `POST /v2/accounts/switch-chain` 422 errors

### DIFF
--- a/.changeset/easy-vans-worry.md
+++ b/.changeset/easy-vans-worry.md
@@ -1,0 +1,5 @@
+---
+"@openfort/react": patch
+---
+
+Fixes repeated `POST /v2/accounts/switch-chain` 422 errors during initial mount with an external (wagmi) wallet. 

--- a/examples/playground/src/components/Showcase/app/SwitchChainCardEVM.tsx
+++ b/examples/playground/src/components/Showcase/app/SwitchChainCardEVM.tsx
@@ -3,7 +3,7 @@ import { useEthereumEmbeddedWallet } from '@openfort/react/ethereum'
 import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { numberToHex } from 'viem'
-import { useAccount, useChainId, useWalletClient } from 'wagmi'
+import { useAccount, useChainId, useSwitchChain } from 'wagmi'
 import { Button } from '@/components/Showcase/ui/Button'
 import { InputMessage } from '@/components/Showcase/ui/InputMessage'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -16,7 +16,7 @@ export const SwitchChainCardEVM = ({ tooltip }: { tooltip?: { hook: string; body
   const core = useOpenfort()
   const { isConnected: wagmiConnected, connector } = useAccount()
   const wagmiChainId = useChainId()
-  const { data: walletClient } = useWalletClient()
+  const { switchChainAsync } = useSwitchChain()
   const [isPending, setIsPending] = useState(false)
   const [error, setError] = useState<Error | null>(null)
   const [data, setData] = useState<{ id: number; name: string } | null>(null)
@@ -41,8 +41,7 @@ export const SwitchChainCardEVM = ({ tooltip }: { tooltip?: { hook: string; body
 
     try {
       if (isExternalWallet) {
-        if (!walletClient) throw new Error('Wallet client not ready')
-        await walletClient.switchChain({ id: targetChainId })
+        await switchChainAsync({ chainId: targetChainId })
       } else {
         const provider =
           embedded.status === 'connected' && embedded.activeWallet

--- a/package.json
+++ b/package.json
@@ -110,7 +110,9 @@
       "brace-expansion@<5.0.5": ">=5.0.5",
       "path-to-regexp@<0.1.13": ">=0.1.13",
       "drizzle-orm": ">=0.45.2",
-      "defu": ">=6.1.5"
+      "defu": ">=6.1.5",
+      "uuid@<14.0.0": ">=14.0.0",
+      "postcss@<8.5.10": ">=8.5.10"
     },
     "auditConfig": {
       "ignoreCves": [

--- a/packages/openfort-react/src/__tests__/providers/CoreOpenfortProvider.bridgeDedup.test.tsx
+++ b/packages/openfort-react/src/__tests__/providers/CoreOpenfortProvider.bridgeDedup.test.tsx
@@ -1,0 +1,176 @@
+import { ChainTypeEnum, EmbeddedState } from '@openfort/openfort-js'
+import { act, render, waitFor } from '@testing-library/react'
+import { createElement } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OpenfortEthereumBridgeValue } from '../../ethereum/OpenfortEthereumBridgeContext'
+import { createMockOpenfortClient, type MockOpenfortClient } from '../mocks/openfortClient'
+
+let mockClient: MockOpenfortClient
+
+vi.mock('../../openfort/core', () => ({
+  createOpenfortClient: () => mockClient,
+  setDefaultClient: () => {},
+}))
+
+// Stable references to prevent referential-identity churn from re-firing memos/effects.
+const stableUseOpenfort = {
+  walletConfig: { ethereum: {} },
+  chainType: ChainTypeEnum.EVM,
+  setChainType: () => {},
+  uiConfig: { walletConnectName: undefined },
+  open: false,
+  route: null,
+  connector: null,
+}
+vi.mock('../../components/Openfort/useOpenfort', () => ({
+  useOpenfort: () => stableUseOpenfort,
+}))
+
+const stableEmptyConnectors: never[] = []
+vi.mock('../../wallets/useExternalConnectors', () => ({
+  mapBridgeConnectorsToWalletProps: () => stableEmptyConnectors,
+}))
+
+vi.mock('../../hooks/useConnectLifecycle', () => ({
+  useConnectLifecycle: () => {},
+}))
+
+const initProviderSpy = vi.fn(() => Promise.resolve())
+const disconnectSpy = vi.fn(() => Promise.resolve())
+
+vi.mock('../../core/strategies/EthereumBridgeStrategy', () => ({
+  createEthereumBridgeStrategy: () => ({
+    kind: 'bridge',
+    chainType: ChainTypeEnum.EVM,
+    isConnected: () => true,
+    getChainId: () => 1,
+    getAddress: () => '0xabc',
+    getConnectRoutes: () => ['embedded', 'external-wallets'],
+    getConnectors: () => [],
+    initProvider: initProviderSpy,
+    disconnect: disconnectSpy,
+  }),
+}))
+
+const { OpenfortEthereumBridgeContext } = await import('../../ethereum/OpenfortEthereumBridgeContext')
+const { CoreOpenfortProvider } = await import('../../openfort/CoreOpenfortProvider')
+
+function makeBridgeValue(overrides: { chainId?: number; address?: `0x${string}` } = {}): OpenfortEthereumBridgeValue {
+  return {
+    account: {
+      address: overrides.address ?? '0xabc',
+      chain: { id: overrides.chainId ?? 1, name: 'mainnet' },
+      isConnected: true,
+      isConnecting: false,
+      isReconnecting: false,
+      connector: { id: 'metamask', name: 'MetaMask' },
+    },
+    chainId: overrides.chainId ?? 1,
+    config: {
+      chains: [{ id: 1 }, { id: 137 }],
+      getClient: () => ({ transport: { url: '' } }),
+    },
+    disconnect: vi.fn(async () => {}),
+    connect: vi.fn(),
+    connectAsync: vi.fn(),
+    reset: vi.fn(),
+    connectors: [],
+    switchChain: {
+      chains: [{ id: 1, name: 'mainnet' }],
+      switchChain: vi.fn(),
+      switchChainAsync: vi.fn(),
+      isPending: false,
+      error: null,
+    },
+  }
+}
+
+const openfortConfig = { baseConfiguration: { publishableKey: 'pk_test_123' } }
+
+function renderWithBridge(bridge: OpenfortEthereumBridgeValue) {
+  return render(
+    createElement(
+      OpenfortEthereumBridgeContext.Provider,
+      { value: bridge },
+      createElement(CoreOpenfortProvider, { openfortConfig }, createElement('div'))
+    )
+  )
+}
+
+function rerenderWithBridge(result: ReturnType<typeof render>, bridge: OpenfortEthereumBridgeValue) {
+  result.rerender(
+    createElement(
+      OpenfortEthereumBridgeContext.Provider,
+      { value: bridge },
+      createElement(CoreOpenfortProvider, { openfortConfig }, createElement('div'))
+    )
+  )
+}
+
+describe('CoreOpenfortProvider — bridge churn dedup', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    mockClient = createMockOpenfortClient()
+    initProviderSpy.mockClear()
+    disconnectSpy.mockClear()
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      const msg = typeof args[0] === 'string' ? args[0] : ''
+      if (msg.includes('was not wrapped in act')) return
+    })
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+    mockClient._test.reset()
+  })
+
+  it('initProvider runs once per chainId despite bridge value churn during wagmi hydration', async () => {
+    const result = renderWithBridge(makeBridgeValue())
+
+    await act(async () => {
+      mockClient._test.setEmbeddedState(EmbeddedState.READY)
+    })
+
+    await waitFor(() => expect(initProviderSpy).toHaveBeenCalledTimes(1))
+
+    // Simulate walletClient hydrating → bridge value object identity changes,
+    // but chainId is unchanged. Strategy is recreated; initProvider must dedup.
+    await act(async () => {
+      rerenderWithBridge(result, makeBridgeValue())
+    })
+
+    // ENS hydrates → another bridge churn.
+    await act(async () => {
+      rerenderWithBridge(result, makeBridgeValue())
+    })
+
+    // isReconnecting flag flips → another bridge churn.
+    await act(async () => {
+      rerenderWithBridge(result, makeBridgeValue())
+    })
+
+    // Allow any pending microtasks/effects to flush before final assertion.
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(initProviderSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('initProvider re-runs when chainId actually changes', async () => {
+    const result = renderWithBridge(makeBridgeValue({ chainId: 1 }))
+
+    await act(async () => {
+      mockClient._test.setEmbeddedState(EmbeddedState.READY)
+    })
+
+    await waitFor(() => expect(initProviderSpy).toHaveBeenCalledTimes(1))
+    expect(initProviderSpy).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1)
+
+    await act(async () => {
+      rerenderWithBridge(result, makeBridgeValue({ chainId: 137 }))
+    })
+
+    await waitFor(() => expect(initProviderSpy).toHaveBeenCalledTimes(2))
+    expect(initProviderSpy).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 137)
+  })
+})

--- a/packages/openfort-react/src/openfort/CoreOpenfortProvider.tsx
+++ b/packages/openfort-react/src/openfort/CoreOpenfortProvider.tsx
@@ -354,9 +354,11 @@ export const CoreOpenfortProvider: React.FC<CoreOpenfortProviderProps> = ({
         initInProgressRef.current = false
       })
     return () => {
+      // Don't reset lastInitRef/initInProgressRef here. Bridge churn during wagmi
+      // hydration (walletClient/ENS resolving) recreates the strategy and re-runs
+      // this effect with the same initKey; resetting would defeat the dedup and
+      // re-fire initProvider → repeated /v2/accounts/switch-chain 422s.
       cancelled = true
-      lastInitRef.current = null
-      initInProgressRef.current = false
     }
   }, [openfort, walletConfig, strategy, evmChainId, storeEmbeddedState])
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,8 @@ overrides:
   path-to-regexp@<0.1.13: '>=0.1.13'
   drizzle-orm: '>=0.45.2'
   defu: '>=6.1.5'
+  uuid@<14.0.0: '>=14.0.0'
+  postcss@<8.5.10: '>=8.5.10'
 
 importers:
 
@@ -608,7 +610,7 @@ importers:
         version: 20.19.37
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.11)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       type-fest:
         specifier: ^3.13.1
         version: 3.13.1
@@ -6261,7 +6263,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: '>=8.5.10'
       tsx: ^4.8.1
       yaml: '>=2.8.3'
     peerDependenciesMeta:
@@ -6277,8 +6279,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.11:
+    resolution: {integrity: sha512-5dDj8+lmvA8XB78SmzGI8NlQoksv7IfutGWeVZxiixHbO+p4LDPT3wuG/D9sM/wrjZZ9I+Siy/e117vbFPxSZg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres@3.4.7:
@@ -7046,7 +7048,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.12
+      postcss: '>=8.5.10'
       typescript: ^5.0.4
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -7250,16 +7252,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -9112,7 +9106,7 @@ snapshots:
       readable-stream: 3.6.2
       socket.io-client: 4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       utf-8-validate: 5.0.10
-      uuid: 8.3.2
+      uuid: 14.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9141,7 +9135,7 @@ snapshots:
       socket.io-client: 4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       tslib: 2.8.1
       util: 0.12.5
-      uuid: 8.3.2
+      uuid: 14.0.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -9162,7 +9156,7 @@ snapshots:
       lodash: 4.18.0
       pony-cause: 2.1.11
       semver: 7.7.4
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9186,7 +9180,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       pony-cause: 2.1.11
       semver: 7.7.4
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9200,7 +9194,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       pony-cause: 2.1.11
       semver: 7.7.4
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -13729,7 +13723,7 @@ snapshots:
       isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
-      uuid: 8.3.2
+      uuid: 14.0.0
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -14514,18 +14508,18 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.11)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.8
+      postcss: 8.5.11
       tsx: 4.21.0
       yaml: 2.8.3
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.8:
+  postcss@8.5.11:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -14888,7 +14882,7 @@ snapshots:
       '@types/ws': 8.18.1
       buffer: 6.0.3
       eventemitter3: 5.0.4
-      uuid: 11.1.0
+      uuid: 14.0.0
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       bufferutil: 4.1.0
@@ -15352,7 +15346,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.11)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -15363,7 +15357,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.11)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.7.6
@@ -15372,7 +15366,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.8
+      postcss: 8.5.11
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -15511,11 +15505,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@11.1.0: {}
-
-  uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
+  uuid@14.0.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 
@@ -15634,7 +15624,7 @@ snapshots:
   vite@5.4.21(@types/node@18.7.18)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.3
-      postcss: 8.5.8
+      postcss: 8.5.11
       rollup: 4.59.0
     optionalDependencies:
       '@types/node': 18.7.18
@@ -15644,7 +15634,7 @@ snapshots:
   vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.3
-      postcss: 8.5.8
+      postcss: 8.5.11
       rollup: 4.59.0
     optionalDependencies:
       '@types/node': 22.19.17
@@ -15657,7 +15647,7 @@ snapshots:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.11
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -15673,7 +15663,7 @@ snapshots:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.11
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
Fixes repeated `POST /v2/accounts/switch-chain` 422 errors during initial mount with an external (wagmi) wallet. The provider no longer re-fires `initProvider` when wagmi's bridge value churns during async hydration (`useWalletClient`, `useEnsName`, reconnect flags) but the meaningful init  parameters (chainId, fee sponsorship policy) are unchanged.  