### PR TITLE
  fix: gate wallet_switchEthereumChain on iframe account state

### DIFF
--- a/.changeset/tough-sites-kneel.md
+++ b/.changeset/tough-sites-kneel.md
@@ -1,0 +1,6 @@
+---
+"@openfort/react": patch
+---
+
+Stops `POST /v2/accounts/switch-chain` 4xx errors logging in console on signup and reload
+

--- a/packages/openfort-react/package.json
+++ b/packages/openfort-react/package.json
@@ -73,7 +73,7 @@
     "react"
   ],
   "dependencies": {
-    "@openfort/openfort-js": "^1.2.1",
+    "@openfort/openfort-js": "1.3.3",
     "buffer": "^6.0.3",
     "detect-browser": "^5.3.0",
     "fast-password-entropy": "^1.1.1",

--- a/packages/openfort-react/src/__tests__/providers/CoreOpenfortProvider.bridgeDedup.test.tsx
+++ b/packages/openfort-react/src/__tests__/providers/CoreOpenfortProvider.bridgeDedup.test.tsx
@@ -164,13 +164,13 @@ describe('CoreOpenfortProvider — bridge churn dedup', () => {
     })
 
     await waitFor(() => expect(initProviderSpy).toHaveBeenCalledTimes(1))
-    expect(initProviderSpy).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, undefined)
+    expect(initProviderSpy).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1)
 
     await act(async () => {
       rerenderWithBridge(result, makeBridgeValue({ chainId: 137 }))
     })
 
     await waitFor(() => expect(initProviderSpy).toHaveBeenCalledTimes(2))
-    expect(initProviderSpy).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 137, undefined)
+    expect(initProviderSpy).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 137)
   })
 })

--- a/packages/openfort-react/src/__tests__/strategies/EthereumStrategy.switchChainGate.test.ts
+++ b/packages/openfort-react/src/__tests__/strategies/EthereumStrategy.switchChainGate.test.ts
@@ -13,10 +13,19 @@ function makeProvider() {
   return { request }
 }
 
-function makeOpenfort(provider: ReturnType<typeof makeProvider>) {
+function makeOpenfort(provider: ReturnType<typeof makeProvider>, walletState: 'missing' | 'sameChain' | 'otherChain') {
+  const wallet =
+    walletState === 'missing'
+      ? null
+      : { address: '0xActiveAccount', chainId: walletState === 'sameChain' ? 84532 : 1, id: 'acc_1' }
+  const get = vi.fn(async () => {
+    if (!wallet) throw new Error('No signer configured')
+    return wallet
+  })
   return {
     embeddedWallet: {
       getEthereumProvider: vi.fn(async () => provider),
+      get,
     },
   } as unknown as Parameters<ReturnType<typeof createEthereumEmbeddedStrategy>['initProvider']>[0]
 }
@@ -33,37 +42,47 @@ function makeBridge(chainId: number): OpenfortEthereumBridgeValue {
   } as unknown as OpenfortEthereumBridgeValue
 }
 
+function switchCalls(provider: ReturnType<typeof makeProvider>) {
+  return provider.request.mock.calls.filter(
+    ([req]) => (req as { method: string }).method === 'wallet_switchEthereumChain'
+  )
+}
+
 describe('Ethereum strategies — wallet_switchEthereumChain gating', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   describe('EthereumEmbeddedStrategy', () => {
-    it('skips wallet_switchEthereumChain when activeEmbeddedAddress is undefined', async () => {
+    it('skips switch when openfort.embeddedWallet.get() throws (signer not configured)', async () => {
       const provider = makeProvider()
-      const openfort = makeOpenfort(provider)
+      const openfort = makeOpenfort(provider, 'missing')
       const strategy = createEthereumEmbeddedStrategy({ ethereum: { chainId: 84532 } })
 
-      await strategy.initProvider(openfort, { ethereum: { chainId: 84532 } }, 84532, undefined)
+      await strategy.initProvider(openfort, { ethereum: { chainId: 84532 } }, 84532)
 
-      const switchCalls = provider.request.mock.calls.filter(
-        ([req]) => (req as { method: string }).method === 'wallet_switchEthereumChain'
-      )
-      expect(switchCalls).toHaveLength(0)
+      expect(switchCalls(provider)).toHaveLength(0)
     })
 
-    it('calls wallet_switchEthereumChain when activeEmbeddedAddress is set', async () => {
+    it('skips switch when wallet.chainId already matches target', async () => {
       const provider = makeProvider()
-      const openfort = makeOpenfort(provider)
+      const openfort = makeOpenfort(provider, 'sameChain')
       const strategy = createEthereumEmbeddedStrategy({ ethereum: { chainId: 84532 } })
 
-      await strategy.initProvider(openfort, { ethereum: { chainId: 84532 } }, 84532, '0xActiveAccount')
+      await strategy.initProvider(openfort, { ethereum: { chainId: 84532 } }, 84532)
 
-      const switchCalls = provider.request.mock.calls.filter(
-        ([req]) => (req as { method: string }).method === 'wallet_switchEthereumChain'
-      )
-      expect(switchCalls).toHaveLength(1)
-      expect(switchCalls[0]?.[0]).toEqual({
+      expect(switchCalls(provider)).toHaveLength(0)
+    })
+
+    it('fires switch when wallet exists and chainId differs', async () => {
+      const provider = makeProvider()
+      const openfort = makeOpenfort(provider, 'otherChain')
+      const strategy = createEthereumEmbeddedStrategy({ ethereum: { chainId: 84532 } })
+
+      await strategy.initProvider(openfort, { ethereum: { chainId: 84532 } }, 84532)
+
+      expect(switchCalls(provider)).toHaveLength(1)
+      expect(switchCalls(provider)[0]?.[0]).toEqual({
         method: 'wallet_switchEthereumChain',
         params: [{ chainId: '0x14a34' }],
       })
@@ -71,32 +90,34 @@ describe('Ethereum strategies — wallet_switchEthereumChain gating', () => {
   })
 
   describe('EthereumBridgeStrategy', () => {
-    it('skips wallet_switchEthereumChain when activeEmbeddedAddress is undefined', async () => {
+    it('skips switch when openfort.embeddedWallet.get() throws (signer not configured)', async () => {
       const provider = makeProvider()
-      const openfort = makeOpenfort(provider)
-      const bridge = makeBridge(84532)
-      const strategy = createEthereumBridgeStrategy(bridge, [])
+      const openfort = makeOpenfort(provider, 'missing')
+      const strategy = createEthereumBridgeStrategy(makeBridge(84532), [])
 
-      await strategy.initProvider(openfort, { ethereum: { chainId: 84532 } }, 84532, undefined)
+      await strategy.initProvider(openfort, { ethereum: { chainId: 84532 } }, 84532)
 
-      const switchCalls = provider.request.mock.calls.filter(
-        ([req]) => (req as { method: string }).method === 'wallet_switchEthereumChain'
-      )
-      expect(switchCalls).toHaveLength(0)
+      expect(switchCalls(provider)).toHaveLength(0)
     })
 
-    it('calls wallet_switchEthereumChain when activeEmbeddedAddress is set', async () => {
+    it('skips switch when wallet.chainId already matches target', async () => {
       const provider = makeProvider()
-      const openfort = makeOpenfort(provider)
-      const bridge = makeBridge(84532)
-      const strategy = createEthereumBridgeStrategy(bridge, [])
+      const openfort = makeOpenfort(provider, 'sameChain')
+      const strategy = createEthereumBridgeStrategy(makeBridge(84532), [])
 
-      await strategy.initProvider(openfort, { ethereum: { chainId: 84532 } }, 84532, '0xActiveAccount')
+      await strategy.initProvider(openfort, { ethereum: { chainId: 84532 } }, 84532)
 
-      const switchCalls = provider.request.mock.calls.filter(
-        ([req]) => (req as { method: string }).method === 'wallet_switchEthereumChain'
-      )
-      expect(switchCalls).toHaveLength(1)
+      expect(switchCalls(provider)).toHaveLength(0)
+    })
+
+    it('fires switch when wallet exists and chainId differs', async () => {
+      const provider = makeProvider()
+      const openfort = makeOpenfort(provider, 'otherChain')
+      const strategy = createEthereumBridgeStrategy(makeBridge(84532), [])
+
+      await strategy.initProvider(openfort, { ethereum: { chainId: 84532 } }, 84532)
+
+      expect(switchCalls(provider)).toHaveLength(1)
     })
   })
 
@@ -107,8 +128,7 @@ describe('Ethereum strategies — wallet_switchEthereumChain gating', () => {
     })
 
     it('returns chainType EVM for bridge strategy', () => {
-      const bridge = makeBridge(84532)
-      const strategy = createEthereumBridgeStrategy(bridge, [])
+      const strategy = createEthereumBridgeStrategy(makeBridge(84532), [])
       expect(strategy.chainType).toBe(ChainTypeEnum.EVM)
     })
   })

--- a/packages/openfort-react/src/core/ConnectionStrategy.ts
+++ b/packages/openfort-react/src/core/ConnectionStrategy.ts
@@ -33,16 +33,7 @@ export interface ConnectionStrategy {
   /** External wallet connectors; only when wagmi/bridge exists. Otherwise []. */
   getConnectors(): ExternalConnectorProps[]
 
-  /**
-   * @param chainId - Current chain for EVM; when provided, uses this for fee sponsorship/rpc instead of config default.
-   * @param activeEmbeddedAddress - Active embedded account address. When undefined, EVM strategies skip
-   *   `wallet_switchEthereumChain` to avoid sending `account: null` to /v2/accounts/switch-chain (422).
-   */
-  initProvider(
-    openfort: Openfort,
-    walletConfig: OpenfortWalletConfig,
-    chainId?: number,
-    activeEmbeddedAddress?: string
-  ): Promise<void>
+  /** @param chainId - Current chain for EVM; when provided, uses this for fee sponsorship/rpc instead of config default. */
+  initProvider(openfort: Openfort, walletConfig: OpenfortWalletConfig, chainId?: number): Promise<void>
   disconnect(openfort: Openfort): Promise<void>
 }

--- a/packages/openfort-react/src/core/strategies/EthereumBridgeStrategy.ts
+++ b/packages/openfort-react/src/core/strategies/EthereumBridgeStrategy.ts
@@ -45,12 +45,7 @@ export function createEthereumBridgeStrategy(
       return connectors
     },
 
-    async initProvider(
-      openfort: Openfort,
-      walletConfig: OpenfortWalletConfig,
-      chainIdOverride?: number,
-      activeEmbeddedAddress?: string
-    ) {
+    async initProvider(openfort: Openfort, walletConfig: OpenfortWalletConfig, chainIdOverride?: number) {
       const chainId = chainIdOverride ?? bridge.chainId
       const feeSponsorshipObj = chainId != null ? resolveEthereumFeeSponsorship(walletConfig, chainId) : undefined
 
@@ -74,20 +69,20 @@ export function createEthereumBridgeStrategy(
         },
       })
       // Tell the provider which chain is active (EIP-1193). Keeps provider in sync with wagmi.
-      // Skip if the chain hasn't changed since last init to avoid spurious 422s.
-      // Skip if no active embedded account: openfort-js sends `account: null` to
-      // /v2/accounts/switch-chain → 422. eth_accounts isn't a reliable proxy here —
-      // it returns the signer address even when the active account isn't set yet.
-      if (chainId != null && chainId !== lastInitChainId && activeEmbeddedAddress) {
-        try {
-          await provider.request({
-            method: 'wallet_switchEthereumChain',
-            params: [{ chainId: `0x${chainId.toString(16)}` }],
-          })
-          lastInitChainId = chainId
-        } catch (switchErr) {
-          logger.warn('[@openfort/react] wallet_switchEthereumChain failed — provider may be on wrong chain', switchErr)
-        }
+      // Real iframe-state check: throws when Account.fromStorage is empty (signer not yet
+      // configured by configure/create/recover). Avoids spurious /v2/accounts/switch-chain
+      // calls (422 with account=null) and redundant calls when already on target chain.
+      if (chainId == null || chainId === lastInitChainId) return
+      const wallet = await openfort.embeddedWallet.get().catch(() => null)
+      if (!wallet?.address || wallet.chainId === chainId) return
+      try {
+        await provider.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: `0x${chainId.toString(16)}` }],
+        })
+        lastInitChainId = chainId
+      } catch (switchErr) {
+        logger.warn('[@openfort/react] wallet_switchEthereumChain failed — provider may be on wrong chain', switchErr)
       }
     },
 

--- a/packages/openfort-react/src/core/strategies/EthereumEmbeddedStrategy.ts
+++ b/packages/openfort-react/src/core/strategies/EthereumEmbeddedStrategy.ts
@@ -59,12 +59,7 @@ export function createEthereumEmbeddedStrategy(walletConfig: OpenfortWalletConfi
       return []
     },
 
-    async initProvider(
-      openfort: Openfort,
-      config: OpenfortWalletConfig,
-      chainIdOverride?: number,
-      activeEmbeddedAddress?: string
-    ) {
+    async initProvider(openfort: Openfort, config: OpenfortWalletConfig, chainIdOverride?: number) {
       const ethereum = config?.ethereum
       const chainId = chainIdOverride ?? ethereum?.chainId ?? DEFAULT_DEV_CHAIN_ID
       const rpcUrls = ethereum?.rpcUrls ?? {}
@@ -76,20 +71,20 @@ export function createEthereumEmbeddedStrategy(walletConfig: OpenfortWalletConfi
       })
       // Tell the provider which chain is active (EIP-1193). Without this, the provider
       // stays on its initial chain (e.g. 80002) while fee sponsorship resolution is per-chain.
-      // Skip if the chain hasn't changed since last init to avoid spurious 422s.
-      // Skip if no active embedded account: openfort-js sends `account: null` to
-      // /v2/accounts/switch-chain → 422. eth_accounts isn't a reliable proxy here —
-      // it returns the signer address even when the active account isn't set yet.
-      if (chainId !== lastInitChainId && activeEmbeddedAddress) {
-        try {
-          await provider.request({
-            method: 'wallet_switchEthereumChain',
-            params: [{ chainId: `0x${chainId.toString(16)}` }],
-          })
-          lastInitChainId = chainId
-        } catch (switchErr) {
-          logger.warn('[@openfort/react] wallet_switchEthereumChain failed — provider may be on wrong chain', switchErr)
-        }
+      // Real iframe-state check: throws when Account.fromStorage is empty (signer not yet
+      // configured by configure/create/recover). Avoids spurious /v2/accounts/switch-chain
+      // calls (422 with account=null) and redundant calls when already on target chain.
+      if (chainId === lastInitChainId) return
+      const wallet = await openfort.embeddedWallet.get().catch(() => null)
+      if (!wallet?.address || wallet.chainId === chainId) return
+      try {
+        await provider.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: `0x${chainId.toString(16)}` }],
+        })
+        lastInitChainId = chainId
+      } catch (switchErr) {
+        logger.warn('[@openfort/react] wallet_switchEthereumChain failed — provider may be on wrong chain', switchErr)
       }
     },
 

--- a/packages/openfort-react/src/openfort/CoreOpenfortProvider.tsx
+++ b/packages/openfort-react/src/openfort/CoreOpenfortProvider.tsx
@@ -294,7 +294,6 @@ export const CoreOpenfortProvider: React.FC<CoreOpenfortProviderProps> = ({
     chainType: ChainTypeEnum
     evmChainId: number | undefined
     feeSponsorshipPolicy: string | undefined
-    hasActiveEmbeddedAddress: boolean
   } | null>(null)
   const initInProgressRef = useRef(false)
 
@@ -316,25 +315,14 @@ export const CoreOpenfortProvider: React.FC<CoreOpenfortProviderProps> = ({
     // Skip if we already initialized with the same parameters
     const feeSponsorshipPolicy =
       evmChainId != null ? resolveEthereumFeeSponsorship(walletConfig, evmChainId)?.policy : undefined
-    // Track whether we had an active embedded address at init time. When it transitions
-    // from absent → present, we re-init so wallet_switchEthereumChain can finally fire
-    // (openfort-js needs the active account set, otherwise it sends `account: null` → 422).
-    const hasActiveEmbeddedAddress = !!storeActiveEmbeddedAddress
-    const initKey = {
-      kind: strategy.kind,
-      chainType: strategy.chainType,
-      evmChainId,
-      feeSponsorshipPolicy,
-      hasActiveEmbeddedAddress,
-    }
+    const initKey = { kind: strategy.kind, chainType: strategy.chainType, evmChainId, feeSponsorshipPolicy }
     const prev = lastInitRef.current
     if (
       prev &&
       prev.kind === initKey.kind &&
       prev.chainType === initKey.chainType &&
       prev.evmChainId === initKey.evmChainId &&
-      prev.feeSponsorshipPolicy === initKey.feeSponsorshipPolicy &&
-      prev.hasActiveEmbeddedAddress === initKey.hasActiveEmbeddedAddress
+      prev.feeSponsorshipPolicy === initKey.feeSponsorshipPolicy
     ) {
       return
     }
@@ -347,7 +335,7 @@ export const CoreOpenfortProvider: React.FC<CoreOpenfortProviderProps> = ({
     initInProgressRef.current = true
     let cancelled = false
     strategy
-      .initProvider(openfort, walletConfig, evmChainId, storeActiveEmbeddedAddress ?? undefined)
+      .initProvider(openfort, walletConfig, evmChainId)
       .then(() => {
         if (cancelled) return
         lastInitRef.current = initKey

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -860,8 +860,8 @@ importers:
   packages/openfort-react:
     dependencies:
       '@openfort/openfort-js':
-        specifier: ^1.2.1
-        version: 1.2.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: 1.3.3
+        version: 1.3.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@solana/kit':
         specifier: ^2.0.0 || ^5.0.0
         version: 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -2243,6 +2243,9 @@ packages:
 
   '@openfort/openfort-js@1.2.1':
     resolution: {integrity: sha512-VREus/0/8uX2QQiDPOtCWPqza088uUO1fC8Tpnf3nP53tnZFz06jDd8osF4v4RAZF24LQnQFpC7clCOqkK6vzA==}
+
+  '@openfort/openfort-js@1.3.3':
+    resolution: {integrity: sha512-T6NitEiCWDTP/pmL/0uc1iydaKw+7KgWJEsvcAstdigLn5s+QmljR43fLHixjIcct/RVIizQWo1mQmRwLdUdig==}
 
   '@openfort/openfort-node@0.10.3':
     resolution: {integrity: sha512-DREorN2ogk2ld3lsD5Fr4mDQnmI5jcNI9W5c1LOZK7R9J31VFNUPUor6G0ey1Z5Xbc8kqhrhgRoPCBMuXjvoaA==}
@@ -9314,6 +9317,26 @@ snapshots:
       '@ethersproject/providers': 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@ethersproject/transactions': 5.8.0
       '@openfort/shield-js': 0.1.35
+      '@sentry/browser': 9.47.1
+      '@sentry/core': 9.47.1
+      axios: 1.15.0
+      axios-retry: 4.5.0(axios@1.15.0)
+      eventemitter3: 5.0.1
+      human-id: 4.1.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@openfort/openfort-js@1.3.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@ethersproject/abi': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/hash': 5.8.0
+      '@ethersproject/keccak256': 5.8.0
+      '@ethersproject/providers': 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@ethersproject/transactions': 5.8.0
+      '@openfort/shield-js': 0.1.36
       '@sentry/browser': 9.47.1
       '@sentry/core': 9.47.1
       axios: 1.15.0


### PR DESCRIPTION
## Summary                                         
  - Replaces unreliable `eth_accounts`/`activeEmbeddedAddress`   
  gate with `openfort.embeddedWallet.get()` to check the iframe's
   real account state before firing `wallet_switchEthereumChain`.
  - Skips the call when the signer isn't yet configured (avoids  
  422 with `account: null`) and when the wallet is already on the
   target chain (avoids redundant calls).                        
  - Race fired during `create()`/`configure()` and surfaced as
  422/400/403 on `POST /v2/accounts/switch-chain` depending on   
  iframe timing.   