### PR TITLE
Fix playground white screen: dedupe wagmi/viem in production build

### DIFF
--- a/examples/playground/vite.config.ts
+++ b/examples/playground/vite.config.ts
@@ -18,6 +18,11 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+    // Force single instances of context-bearing singletons. pnpm can install
+    // multiple physical copies of @wagmi/core (different peer-dep hashes); when
+    // both get bundled, WagmiProvider and useConfig read different React
+    // contexts and the app throws "useConfig must be used within WagmiProvider".
+    dedupe: ['react', 'react-dom', 'wagmi', 'viem', '@tanstack/react-query'],
   },
   server: {
     allowedHosts: true,


### PR DESCRIPTION
## Summary
`playground.openfort.io` was white-screening on load with an uncaught `WagmiProviderNotFoundError: useConfig must be used within WagmiProvider`.

Root cause: pnpm installs multiple physical copies of `@wagmi/core` (same version, different peer-dependency hashes). The Vite **production** bundle included more than one, so `WagmiProvider` and `useConfig` resolved different React context instances and the app crashed before rendering. Dev mode was unaffected (single resolution), and Vercel's build check passed because it only verifies the build compiles, not that the page renders.

Fix: add `resolve.dedupe` in `vite.config.ts` for `react`, `react-dom`, `wagmi`, `viem`, and `@tanstack/react-query` so the bundle contains a single instance of each.

## Test plan
- [x] Reproduced the white screen with `pnpm build && pnpm preview` (prod build)
- [x] After the fix: prod preview renders, no console errors
- [x] Guest login → EVM dashboard (wagmi-backed signatures / write-contract / switch-chain cards) renders and functions
- [ ] Confirm on the Vercel preview deployment for this PR