### PR TITLE
Polish hook inspector pages: header, docs link, sample-code toggle, type hints

### DIFF
--- a/examples/playground/src/components/Variable/HookVariable.tsx
+++ b/examples/playground/src/components/Variable/HookVariable.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useSearch } from '@tanstack/react-router'
-import { CheckIcon, Code2Icon } from 'lucide-react'
+import { Braces, CheckIcon, Code2Icon, ExternalLink } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -19,6 +19,7 @@ export const HookVariable = <TOptions extends object, TResult extends object>({
   defaultOptions = EMPTY_OPTIONS as TOptions,
   optionsVariables,
   importPath = '@openfort/react',
+  docsUrl = 'https://www.openfort.io/docs',
 }: {
   hook: (opts?: TOptions) => TResult
   name: string
@@ -30,6 +31,8 @@ export const HookVariable = <TOptions extends object, TResult extends object>({
   optionsVariables?: Record<string, HookInput>
   /** Import path for sample code (default: @openfort/react). Use e.g. @openfort/react/wagmi for wagmi hooks. */
   importPath?: string
+  /** Link to this hook's documentation. Defaults to the Openfort docs home. */
+  docsUrl?: string
 }) => {
   const [opts, setOpts] = useState<TOptions>(defaultOptions)
 
@@ -91,25 +94,54 @@ function SampleComponent() {
   }, [params.focus, navigate])
 
   const [copied, setCopied] = useState(false)
+  const [showCode, setShowCode] = useState(false)
 
   return (
     <div className="flex flex-col gap-3 text-sm">
       {description && <p className="text-sm text-muted-foreground">{description}</p>}
       <div className="overflow-hidden rounded-lg border bg-card">
         <div className="flex items-center justify-between gap-2 border-b bg-muted/50 px-3 py-2">
-          <div className="flex items-center gap-2 font-mono text-sm font-medium">
+          <div className="flex min-w-0 items-center gap-2 font-mono text-sm">
             <span className="text-muted-foreground">{'›'}</span>
-            {name}
+            <span className="font-medium">{name}</span>
+            <span className="hidden truncate text-xs text-muted-foreground md:inline">
+              import {'{'} {name} {'}'} from '{importPath}'
+            </span>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-1">
             <span
               className={cn(
-                'text-xs text-muted-foreground transition-opacity duration-300',
+                'mr-1 text-xs text-muted-foreground transition-opacity duration-300',
                 copied ? 'opacity-100' : 'opacity-0'
               )}
             >
               Copied
             </span>
+            <Tooltip delayDuration={500}>
+              <TooltipTrigger asChild>
+                <Button asChild variant="ghost" size="icon" className="size-7">
+                  <a href={docsUrl} target="_blank" rel="noopener noreferrer" aria-label="Open documentation">
+                    <ExternalLink className="size-4" />
+                  </a>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Docs</TooltipContent>
+            </Tooltip>
+            <Tooltip delayDuration={500}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  type="button"
+                  className={cn('size-7', showCode && 'bg-accent text-foreground')}
+                  aria-pressed={showCode}
+                  onClick={() => setShowCode((v) => !v)}
+                >
+                  <Braces className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{showCode ? 'Hide' : 'Show'} sample code</TooltipContent>
+            </Tooltip>
             <Tooltip delayDuration={500}>
               <TooltipTrigger asChild>
                 <Button
@@ -143,6 +175,11 @@ function SampleComponent() {
             </Tooltip>
           </div>
         </div>
+        {showCode && (
+          <pre className="overflow-x-auto border-b bg-background/60 px-4 py-3 font-mono text-xs leading-relaxed text-muted-foreground">
+            {sample}
+          </pre>
+        )}
         <div className="flex flex-col gap-4 p-4 font-mono text-sm">
           <div className="flex flex-col gap-2">
             <span className="text-xs uppercase tracking-wide text-muted-foreground">Options</span>

--- a/examples/playground/src/components/Variable/Variable.tsx
+++ b/examples/playground/src/components/Variable/Variable.tsx
@@ -101,6 +101,14 @@ const formatValue = (val: any, valueType: string, _name: string) => {
   }
 }
 
+/** Short TS type label shown after a top-level value. Uses the explicit
+ * typescriptType when provided, otherwise infers it for primitives only. */
+const getTypeLabel = (variable: HookInput | undefined, valueType: string): string | undefined => {
+  if (variable?.typescriptType) return variable.typescriptType
+  if (valueType === 'boolean' || valueType === 'string' || valueType === 'number') return valueType
+  return undefined
+}
+
 const EditableVariable = ({
   variable,
   value,
@@ -235,6 +243,7 @@ export const BaseVariable = ({
   const isEditable = hasVariable && !!variable.onEdit
 
   const actualType = getValueType(value)
+  const typeLabel = depth === 0 ? getTypeLabel(variable, actualType) : undefined
   const isExpandable =
     (actualType === 'object' || actualType === 'array' || (actualType === 'function' && hasVariable)) &&
     value !== null &&
@@ -333,6 +342,7 @@ export const BaseVariable = ({
             formatValue(value, actualType, name)
           )}
         </span>
+        {typeLabel && <span className="text-xs text-muted-foreground/70">: {typeLabel}</span>}
       </div>
     )
   }
@@ -368,6 +378,7 @@ export const BaseVariable = ({
         <span className={cn('font-mono text-sm', getValueColor(actualType, 'text'))}>
           {formatValue(value, actualType, name)}
         </span>
+        {typeLabel && <span className="text-xs text-muted-foreground/70">: {typeLabel}</span>}
       </button>
       {renderExpandedContent()}
     </div>


### PR DESCRIPTION
## Summary
Improves every hook inspector page (all render through `HookVariable`, so one change propagates to ~20 pages). Keeps the existing live-console feel ("Polished console" direction), just clearer and more educational.

- **Header bar**: shows the `import { useX } from '@openfort/react'` statement, a **Docs** link (`docsUrl` prop, defaults to the Openfort docs home — override per hook later), a **sample-code toggle**, and the existing copy button.
- **Sample code, visible**: the generated usage snippet can now be expanded inline instead of only copied.
- **Inline type hints**: each top-level value shows its TypeScript type (`: boolean`, `: number`, `: ConnectedEmbeddedEthereumWallet | null`, `: (data: any) => void`), using the existing `typescriptType` metadata when present and inferring it for primitives otherwise.

## Test plan
- [x] `/wallet/useEthereumEmbeddedWallet` renders header + type hints; code toggle reveals the snippet
- [x] knip clean, no new console errors
- [ ] Spot-check a few auth/util hook pages on the Vercel preview