### PR TITLE
playground: revert widget auto-open, trim auth providers, auto-create wallet, flatten wallet list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ examples/playground/tests/.auth/
 
 docs/
 semgrep-results-001/
+.gstack/

--- a/examples/playground/src/components/Showcase/app/EmbeddedWalletsList.tsx
+++ b/examples/playground/src/components/Showcase/app/EmbeddedWalletsList.tsx
@@ -1,6 +1,6 @@
 /**
  * Shared embedded wallets list for evm (wagmi) and svm.
- * Renders parent/child hierarchy (EOA → Smart Account) with CornerDownRightIcon.
+ * Renders all wallets at the top level (EOA, Smart Account, Delegated Account).
  */
 
 import {
@@ -12,15 +12,7 @@ import {
 } from '@openfort/react'
 import { Link } from '@tanstack/react-router'
 import { AnimatePresence } from 'framer-motion'
-import {
-  ChevronLeftIcon,
-  CornerDownRightIcon,
-  EyeIcon,
-  EyeOffIcon,
-  Loader2,
-  RefreshCwIcon,
-  WalletIcon,
-} from 'lucide-react'
+import { ChevronLeftIcon, EyeIcon, EyeOffIcon, Loader2, RefreshCwIcon, WalletIcon } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { MP } from '@/components/motion/motion'
 import { WalletRecoveryIcon } from '@/components/Showcase/app/WalletRecoveryIcon'
@@ -216,11 +208,9 @@ const CreateWalletButton = ({ ethereum }: { ethereum: EthereumWalletState }) => 
 const WalletButton = ({
   wallet,
   setActive,
-  nested,
 }: {
   wallet: ConnectedEmbeddedEthereumWallet
   setActive: (opts: { address: `0x${string}`; password?: string; recoveryMethod?: RecoveryMethod }) => Promise<void>
-  nested?: boolean
 }) => {
   const [password, setPassword] = useState('example-password')
   const [showPasswordInput, setShowPasswordInput] = useState(false)
@@ -254,7 +244,7 @@ const WalletButton = ({
 
   if (showPasswordInput) {
     return (
-      <form className={cn('flex w-full gap-2 password-input', nested && 'ml-5')}>
+      <form className="flex w-full gap-2 password-input">
         <Input
           type={showPassword ? 'text' : 'password'}
           placeholder="Enter password"
@@ -292,8 +282,7 @@ const WalletButton = ({
   }
 
   return (
-    <div className={cn('flex items-center gap-1', nested && 'ml-5')}>
-      {nested && <CornerDownRightIcon className="h-3 w-3 shrink-0 opacity-40" />}
+    <div className="flex items-center gap-1">
       <Button
         type="button"
         variant="outline"
@@ -332,19 +321,17 @@ const WalletTooltipItem = ({
   wallet,
   index,
   setActive,
-  nested,
 }: {
   wallet: ConnectedEmbeddedEthereumWallet
   index: number
   activeWallet: ConnectedEmbeddedEthereumWallet | null
   connectingAddress: string | undefined
   setActive: (opts: { address: `0x${string}`; password?: string; recoveryMethod?: RecoveryMethod }) => Promise<void>
-  nested?: boolean
 }) => (
   <Tooltip delayDuration={500}>
     <TooltipTrigger asChild>
       <div>
-        <WalletButton wallet={wallet} setActive={setActive} nested={nested} />
+        <WalletButton wallet={wallet} setActive={setActive} />
       </div>
     </TooltipTrigger>
     <TooltipContent>
@@ -424,58 +411,22 @@ export function EmbeddedWalletsList({
     })
   }, [ethereum.wallets, currentChainId])
 
-  const { topLevel, childrenByOwner } = useMemo(() => {
-    const ownerAddresses = new Set(wallets.map((w) => w.address.toLowerCase()))
-    const childrenByOwner = new Map<string, ConnectedEmbeddedEthereumWallet[]>()
-    const topLevel: ConnectedEmbeddedEthereumWallet[] = []
-
-    for (const wallet of wallets) {
-      const owner = wallet.ownerAddress?.toLowerCase()
-      if (owner && ownerAddresses.has(owner) && owner !== wallet.address.toLowerCase()) {
-        const existing = childrenByOwner.get(owner) ?? []
-        existing.push(wallet)
-        childrenByOwner.set(owner, existing)
-      } else {
-        topLevel.push(wallet)
-      }
-    }
-
-    return { topLevel, childrenByOwner }
-  }, [wallets])
-
   // When an external wallet is active, suppress embedded active indicators
   const effectiveActiveWallet = isExternalActive ? null : activeWallet
 
   return (
     <div className="space-y-2">
-      {topLevel.map((wallet) => {
-        const children = childrenByOwner.get(wallet.address.toLowerCase())
-        const walletIndex = wallets.indexOf(wallet)
+      {wallets.map((wallet, walletIndex) => {
         const displayWallet = isExternalActive ? { ...wallet, isActive: false } : wallet
         return (
-          <div key={wallet.id} className="space-y-1">
-            <WalletTooltipItem
-              wallet={displayWallet}
-              index={walletIndex}
-              activeWallet={effectiveActiveWallet}
-              connectingAddress={connectingAddress}
-              setActive={setActive}
-            />
-            {children?.map((child) => {
-              const displayChild = isExternalActive ? { ...child, isActive: false } : child
-              return (
-                <WalletTooltipItem
-                  key={child.id}
-                  wallet={displayChild}
-                  index={wallets.indexOf(child)}
-                  activeWallet={effectiveActiveWallet}
-                  connectingAddress={connectingAddress}
-                  setActive={setActive}
-                  nested
-                />
-              )
-            })}
-          </div>
+          <WalletTooltipItem
+            key={wallet.id}
+            wallet={displayWallet}
+            index={walletIndex}
+            activeWallet={effectiveActiveWallet}
+            connectingAddress={connectingAddress}
+            setActive={setActive}
+          />
         )
       })}
       <div className="flex gap-2">

--- a/examples/playground/src/lib/useAppStore.ts
+++ b/examples/playground/src/lib/useAppStore.ts
@@ -36,11 +36,7 @@ const defaultWalletConfig: OpenfortWalletConfig = {
   createEncryptedSessionEndpoint:
     import.meta.env.VITE_CREATE_ENCRYPTED_SESSION_ENDPOINT ||
     'https://create-next-app.openfort.io/api/protected-create-encryption-session',
-  // Do NOT auto-create wallets on chain switch or after auth.
-  // When switching EVM↔SVM the provider tree remounts; auto-creation here creates wallets
-  // without the right session key config and with no user confirmation. Use the explicit
-  // "Create wallet" UI instead.
-  connectOnLogin: false,
+  connectOnLogin: true,
 
   requestWalletRecoverOTP: async ({ userId, email, phone }) => {
     await fetch(import.meta.env.VITE_REQUEST_WALLET_RECOVER_OTP_ENDPOINT, {
@@ -61,15 +57,11 @@ const defaultProviderOptions: Parameters<typeof OpenfortProvider>[0] = {
     mode: undefined,
     customTheme: undefined,
     authProviders: [
-      // AuthProvider.EMAIL_PASSWORD,
+      AuthProvider.GUEST,
       AuthProvider.EMAIL_OTP,
       AuthProvider.PHONE,
-      AuthProvider.GUEST,
-      AuthProvider.WALLET,
       AuthProvider.GOOGLE,
-      AuthProvider.FACEBOOK,
-      AuthProvider.TWITTER,
-      AuthProvider.DISCORD,
+      AuthProvider.WALLET,
     ],
     phoneConfig: {
       defaultCountry: 'us',

--- a/examples/playground/src/routes/_showcase/showcase/auth/index.tsx
+++ b/examples/playground/src/routes/_showcase/showcase/auth/index.tsx
@@ -1,7 +1,6 @@
 import { useUI } from '@openfort/react'
 import { createFileRoute } from '@tanstack/react-router'
 import { ArrowRight } from 'lucide-react'
-import { useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Logo } from '@/components/ui/logo'
@@ -12,11 +11,6 @@ export const Route = createFileRoute('/_showcase/showcase/auth/')({
 
 function RouteComponent() {
   const ui = useUI()
-
-  // Open the Openfort widget automatically when the onboarding screen mounts.
-  useEffect(() => {
-    ui.open()
-  }, [])
 
   return (
     <div className="flex flex-1 items-center justify-center p-4">

--- a/examples/playground/tests/pages/auth.page.ts
+++ b/examples/playground/tests/pages/auth.page.ts
@@ -23,14 +23,15 @@ export class AuthPage {
    * Sign up as a guest via the Openfort widget, then create a wallet on the dashboard.
    *
    * Flow:
-   *  1. The onboarding screen auto-opens the widget; click "Guest" inside the modal
+   *  1. Click "Connect Wallet" on the onboarding screen to open the widget, then "Guest"
    *  2. Auth redirects to / (dashboard) — no wallet yet (connectOnLogin=false)
    *  3. Dismiss the widget if it lingers on a create-wallet step
    *  4. In the Wallets card: Create new wallet → Smart Account (EVM only) → Automatic
    *  5. Wait for "Connected with <address>"
    */
   async continueAsGuest(mode: PlaygroundMode) {
-    // Onboarding auto-opens the Openfort widget modal; sign up via the "Guest" option.
+    // Open the Openfort widget modal from the onboarding screen, then sign up via "Guest".
+    await safeClick(this.page, /^connect wallet$/i, 30_000)
     await expect(this.page.getByPlaceholder('Enter your email')).toBeVisible({ timeout: 30_000 })
     await this.page.getByRole('button', { name: /^guest$/i }).click()
 

--- a/examples/playground/tests/specs/auth.spec.ts
+++ b/examples/playground/tests/specs/auth.spec.ts
@@ -11,10 +11,11 @@ test.describe('auth screen renders correctly', () => {
       await page.goto('/showcase/auth', { waitUntil: 'domcontentloaded' })
       await expect(page).toHaveURL(/\/showcase\/auth/i)
 
-      // Landing card behind the widget
+      // Landing card with the Connect Wallet button
       await expect(page.getByText(/connect to start/i)).toBeVisible({ timeout: 20_000 })
+      await page.getByRole('button', { name: /^connect wallet$/i }).click()
 
-      // The widget modal auto-opens with the configured sign-in options
+      // The widget modal opens with the configured sign-in options
       await expect(page.getByPlaceholder('Enter your email')).toBeVisible({ timeout: 30_000 })
       await expect(page.getByRole('button', { name: /^guest$/i })).toBeVisible({ timeout: 30_000 })
     })


### PR DESCRIPTION
## Summary
Four small playground changes that arrived together while polishing the post-#251 onboarding flow.

### 1. Revert widget auto-open on the auth screen
`/showcase/auth` was opening the Openfort widget on mount via `useEffect`, which produced unexpected behaviour. The "Connect Wallet" button is kept as the explicit entry point (still calls `ui.open()` on click).

### 2. Trim auth providers
The configured list is now `GUEST, EMAIL_OTP, PHONE, GOOGLE, WALLET` (was the full set including Facebook, Twitter, Discord). Wallet still requires `VITE_WALLETCONNECT_PROJECT_ID` to render in the modal.

### 3. Auto-create wallet after auth
`walletConfig.connectOnLogin: true` so the SDK creates a wallet automatically after authentication, removing the extra manual step. Previously this was set to `false` with a comment about EVM↔SVM mode switches; the new behaviour matches the SDK default.

### 4. Flatten the Wallets card
`EmbeddedWalletsList.tsx` no longer renders Smart Accounts / Delegated Accounts as nested children of their EOA. All wallets appear at the top level. Playwright tests updated to click "Connect Wallet" before asserting the widget modal.

## Test plan
- [ ] `pnpm dev` → visit `/showcase/auth` → widget does NOT auto-open
- [ ] Click "Connect Wallet" → modal shows Guest, Email, Phone, Google
- [ ] Sign in as Guest → an EOA appears in the Wallets card automatically
- [ ] Create a Smart Account on EVM → renders at the top level (no nesting under the EOA)
- [ ] `pnpm test:e2e` auth specs pass for both EVM and SVM modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)