### PR TITLE
feat(playground): nest SA under owner EOA, pin Delegated create to active chain

### DIFF
--- a/examples/playground/src/components/Showcase/app/EmbeddedWalletsList.tsx
+++ b/examples/playground/src/components/Showcase/app/EmbeddedWalletsList.tsx
@@ -94,6 +94,12 @@ const CreateWalletButton = ({ ethereum }: { ethereum: EthereumWalletState }) => 
     return () => document.removeEventListener('click', handleClickOutsideCreateWallet)
   }, [])
 
+  // The SDK falls back to the config's default chain when no chainId is passed,
+  // which can deploy a Smart Account / Delegated on the wrong chain when the
+  // user is browsing a different active chain. Always pin creation to the
+  // currently-active chain so Polygon Amoy creates land on Amoy, not Base.
+  const activeChainId = ethereum.status === 'connected' ? ethereum.chainId : undefined
+
   const handleCreateWallet = async (recoveryMethod: RecoveryMethod) => {
     if (!selectedAccountType) return
     const accountType = selectedAccountType
@@ -103,6 +109,7 @@ const CreateWalletButton = ({ ethereum }: { ethereum: EthereumWalletState }) => 
     try {
       const options = {
         accountType,
+        ...(accountType !== AccountTypeEnum.EOA && activeChainId != null && { chainId: activeChainId }),
         ...(recoveryMethod === RecoveryMethod.PASSWORD && {
           recoveryMethod: RecoveryMethod.PASSWORD,
           password: 'example-password',
@@ -477,16 +484,44 @@ export function EmbeddedWalletsList({
     })
   }, [ethereum.wallets, currentChainId])
 
+  // Smart Accounts are owned by an EOA at a different address. Group SAs under
+  // their owner EOA when present in the list. SAs whose owner is missing from
+  // the list (e.g. owner EOA not loaded yet) render at the top level.
+  const eoaAddressesInList = useMemo(
+    () => new Set(wallets.filter((w) => w.accountType === AccountTypeEnum.EOA).map((w) => w.address.toLowerCase())),
+    [wallets]
+  )
+  const ownedSmartAccountsByOwner = useMemo(() => {
+    const map = new Map<string, ConnectedEmbeddedEthereumWallet[]>()
+    for (const w of wallets) {
+      if (w.accountType !== AccountTypeEnum.SMART_ACCOUNT) continue
+      const owner = w.ownerAddress?.toLowerCase()
+      if (!owner || !eoaAddressesInList.has(owner)) continue
+      const list = map.get(owner) ?? []
+      list.push(w)
+      map.set(owner, list)
+    }
+    return map
+  }, [wallets, eoaAddressesInList])
+  const topLevelWallets = useMemo(() => {
+    return wallets.filter((w) => {
+      if (w.accountType !== AccountTypeEnum.SMART_ACCOUNT) return true
+      const owner = w.ownerAddress?.toLowerCase()
+      return !owner || !eoaAddressesInList.has(owner)
+    })
+  }, [wallets, eoaAddressesInList])
+
   // When an external wallet is active, suppress embedded active indicators
   const effectiveActiveWallet = isExternalActive ? null : activeWallet
 
   return (
     <div className="space-y-2">
-      {wallets.map((wallet, walletIndex) => {
+      {topLevelWallets.map((wallet, walletIndex) => {
         const displayWallet = isExternalActive ? { ...wallet, isActive: false } : wallet
         const isEoa = wallet.accountType === AccountTypeEnum.EOA
         const isDelegatedHere =
           isEoa && currentChainId != null && delegatedAddressesOnChain.has(wallet.address.toLowerCase())
+        const ownedSmartAccounts = isEoa ? (ownedSmartAccountsByOwner.get(wallet.address.toLowerCase()) ?? []) : []
         return (
           <div key={wallet.id}>
             <WalletTooltipItem
@@ -497,6 +532,20 @@ export function EmbeddedWalletsList({
               setActive={setActive}
             />
             {isDelegatedHere && currentChainId != null && <DelegationSubRow chainId={currentChainId} />}
+            {ownedSmartAccounts.map((sa) => {
+              const saDisplay = isExternalActive ? { ...sa, isActive: false } : sa
+              return (
+                <div key={sa.id} className="ml-6 mt-1">
+                  <WalletTooltipItem
+                    wallet={saDisplay}
+                    index={walletIndex}
+                    activeWallet={effectiveActiveWallet}
+                    connectingAddress={connectingAddress}
+                    setActive={setActive}
+                  />
+                </div>
+              )
+            })}
           </div>
         )
       })}


### PR DESCRIPTION
## Summary

Follow-up to the prior PR addressing the issues you flagged after merging.

- **Nest Smart Accounts under their owner EOA.** The playground creates a fresh EOA when you pick "Smart Account" and then deploys the SA on top of it. The SA now renders as a nested sub-row under that EOA (matched by `ownerAddress`). Orphan SAs (owner not in the loaded list) stay top-level.
- **Fix Delegated-created-on-wrong-chain (root cause of AA24).** The playground's `create({ accountType: DELEGATED_ACCOUNT })` did not pass `chainId`, so the SDK fell back to its default chain (Base Sepolia). Creating a Delegated while browsing Polygon Amoy actually deployed it on Base, then "Mint Tokens" hit `AA24 signature error` because the active chain (Amoy) didn't match the chain the Delegated lived on. The create call now pins to `ethereum.chainId`. Same fix applies to Smart Account creation.

## Bug B (Calibur not available on chainId 80002) — SDK-side, not playground

When the active wallet is a Delegated on Base Sepolia and you try to switch to Polygon Amoy, the backend rejects because the Calibur delegation implementation isn't deployed on Amoy. The error bubbles through `wallet_switchEthereumChain` and is shown verbatim in the Switch chain card.

This is a backend/SDK issue, not a playground bug. The playground can't selectively pre-validate without per-chain implementation metadata. Two SDK-side options worth considering separately:
1. Backend returns a clearer message: "Active wallet's implementation isn't available on chain X. Switch wallet first or create one for that chain."
2. SDK auto-falls-back to the owner EOA when switching to a chain where the active SA/Delegated isn't supported.

Happy to file a separate SDK-side change if you want.

## Test plan
- [x] Auth → guest → Create Smart Account → SA renders nested under its newly-created owner EOA, indented and highlighted as active
- [x] Polygon Amoy active → Create Delegated → SA created chain is Polygon Amoy, badge reads "Polygon Amoy" (verified by code path; previous behavior put it on Base)
- [x] Existing tests still pass (auth.spec, wallets-create-new svm, setups)
- [x] `tsc --noEmit` produces the same 11 pre-existing errors as main; `biome check` clean on touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)