### PR TITLE
fix(provider): remove @vite-ignore so @openfort/react works under Vite

### DIFF
--- a/.changeset/fix-vite-dep-prebundle.md
+++ b/.changeset/fix-vite-dep-prebundle.md
@@ -1,0 +1,5 @@
+---
+'@openfort/react': patch
+---
+
+Fix blank screen in Vite apps. The `OpenfortProvider` lazy imports carried a `@vite-ignore` hint, which made Vite's dependency pre-bundler keep the relative dynamic imports external — so they resolved against `node_modules/.vite/deps` instead of the package and the provider failed to load in dev ("Failed to resolve import ../../solana/SolanaContext.js"). Removing the hint lets Vite (and Rollup/webpack) resolve and code-split the chunks correctly.

--- a/packages/openfort-react/src/components/Openfort/OpenfortProvider.tsx
+++ b/packages/openfort-react/src/components/Openfort/OpenfortProvider.tsx
@@ -37,17 +37,22 @@ import {
   UIAuthProvider,
 } from './types'
 
+// These chunks are lazy-loaded with static specifiers so every bundler (Vite, Rollup, webpack)
+// can resolve and code-split them. Do NOT add a vite-ignore hint to these imports: it makes
+// Vite's dependency pre-bundler keep the import external, so the relative path resolves against
+// node_modules/.vite/deps instead of the package and the provider fails to load in dev
+// ("Failed to resolve import ../../solana/SolanaContext.js"), blanking any Vite app.
 const SolanaContextProvider = lazy(() =>
-  import(/* @vite-ignore */ '../../solana/SolanaContext').then((m) => ({ default: m.SolanaContextProvider }))
+  import('../../solana/SolanaContext').then((m) => ({ default: m.SolanaContextProvider }))
 )
 
 const LazyEmbeddedWalletWagmiSync = lazy(() =>
-  import(/* @vite-ignore */ '../../wagmi/useEmbeddedWalletWagmiSync').then((m) => ({
+  import('../../wagmi/useEmbeddedWalletWagmiSync').then((m) => ({
     default: m.EmbeddedWalletWagmiSync,
   }))
 )
 
-const LazyConnectKitModal = lazy(() => import(/* @vite-ignore */ '../ConnectModal'))
+const LazyConnectKitModal = lazy(() => import('../ConnectModal'))
 
 /** {@link OpenfortProvider} props. */
 type OpenfortProviderProps = {


### PR DESCRIPTION
## Problem

`@openfort/react` blanks the screen in **any Vite + React app** — confirmed on a stock `npm create vite` (React-TS) project with nothing but the SDK installed. The dev server shows:

```
[vite] Failed to resolve import "../../solana/SolanaContext.js"
       from "node_modules/.vite/deps/@openfort_react.js". Does the file exist?
```

`OpenfortProvider` lazy-loads three chunks via dynamic `import()`, each with a `/* @vite-ignore */` hint:

```tsx
const SolanaContextProvider     = lazy(() => import(/* @vite-ignore */ '../../solana/SolanaContext')...)
const LazyEmbeddedWalletWagmiSync = lazy(() => import(/* @vite-ignore */ '../../wagmi/useEmbeddedWalletWagmiSync')...)
const LazyConnectKitModal       = lazy(() => import(/* @vite-ignore */ '../ConnectModal'))
```

The hint tells Vite's dependency optimizer to keep these imports external. When Vite pre-bundles the package into `node_modules/.vite/deps/@openfort_react.js`, the relative specifiers then resolve against the **deps directory** instead of the package, so they 404 and the provider never mounts.

Next.js is unaffected (its bundler ignores the Vite-only hint), which is why this stayed hidden — it only bites Vite, the most common React stack.

## Fix

Remove the `@vite-ignore` hints. The specifiers are static strings, so Vite (and Rollup/webpack) resolve and **code-split** them correctly; `React.lazy` still defers loading.

The hint provided no size/speed benefit — the lazy code-splitting comes from `React.lazy` + `import()`, not the comment. Measured after the fix: `SolanaContext` loads as a separate ~3 KB on-demand chunk and heavy Solana deps stay out of the main bundle.

## Verification

- Reproduced on a fresh `npm create vite@latest --template react-ts` app (npm, default Vite 8, only `@openfort/react` + peers, minimal `OpenfortProvider`) → blank screen + the error above.
- Built this change, packed it, installed the tarball into that app → renders, no resolve error, Solana chunk split correctly.
- `pnpm --filter @openfort/react build` succeeds; built output has bare `import('../../solana/SolanaContext.js')`.

Added a code comment so the hint isn't reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)