### PR TITLE
Funding: wallet Deposit hub (crypto, exchange, card)

### DIFF
--- a/examples/quickstarts/openfort-ui/src/App.tsx
+++ b/examples/quickstarts/openfort-ui/src/App.tsx
@@ -1,7 +1,17 @@
+import { OpenfortButton } from '@openfort/react'
 import { Main } from './components/cards/main'
 
 function App() {
-  return <Main />
+  return (
+    <>
+      {/* Wallet/connect button — opens the modal. When connected it lands on the
+          Connected screen, where the Deposit hub button lives. */}
+      <div style={{ position: 'fixed', top: 16, right: 16, zIndex: 50 }}>
+        <OpenfortButton />
+      </div>
+      <Main />
+    </>
+  )
 }
 
 export default App

--- a/examples/quickstarts/openfort-ui/src/components/cards/funding.tsx
+++ b/examples/quickstarts/openfort-ui/src/components/cards/funding.tsx
@@ -1,0 +1,82 @@
+import { useFunding } from '@openfort/react'
+import { useState } from 'react'
+import { useAccount } from 'wagmi'
+import { TruncateData } from '../ui/TruncateData'
+
+// Mainnet USDC across a few chains → received as USDC on Base.
+const SOURCES = [
+  { label: 'USDC · Polygon', chain: 'eip155:137', currency: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359' },
+  { label: 'USDC · Arbitrum', chain: 'eip155:42161', currency: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' },
+  { label: 'USDC · Base', chain: 'eip155:8453', currency: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' },
+  { label: 'USDC · Optimism', chain: 'eip155:10', currency: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85' },
+]
+const DEST_BASE_USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const inputClass = 'w-full rounded bg-zinc-800 border border-zinc-700 px-3 py-2 text-sm text-zinc-100'
+
+export const Funding = () => {
+  const { address } = useAccount()
+  const { session, status, error, isAvailable, fund, reset } = useFunding()
+  const [idx, setIdx] = useState(0)
+  const [amount, setAmount] = useState('10')
+  const pm = session?.paymentMethod ?? null
+  const source = SOURCES[idx]
+
+  const run = () => {
+    if (!address || !source) return
+    const units = String(Math.round(Number(amount || '0') * 1e6))
+    void fund(
+      { chain: 'eip155:8453', currency: DEST_BASE_USDC, address },
+      { type: 'evm', source: { chain: source.chain, currency: source.currency, amount: units } }
+    ).catch(() => {})
+  }
+
+  return (
+    <div className="flex flex-col w-full">
+      <h2 className="mb-3">Headless funding</h2>
+      <p className="mb-4 text-sm text-zinc-400">
+        Drive a funding session directly with <code>useFunding()</code> — no modal. Pick a source, get a real Relay
+        deposit address, and send.
+      </p>
+
+      {!isAvailable && <p className="mb-3 text-sm text-amber-400">Set uiConfig.fundingBaseUrl to enable.</p>}
+
+      {!pm ? (
+        <div className="space-y-3">
+          <select className={inputClass} value={idx} onChange={(e) => setIdx(Number(e.target.value))}>
+            {SOURCES.map((s, i) => (
+              <option key={s.chain} value={i}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+          <input className={inputClass} inputMode="decimal" value={amount} onChange={(e) => setAmount(e.target.value)} />
+          <button type="button" className="btn" onClick={run} disabled={!address || !isAvailable}>
+            Get deposit address
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-2 text-sm">
+          <div>
+            Status: <span className="text-zinc-300">{status}</span>
+          </div>
+          <div>
+            Send {amount} USDC on {source?.label} to:
+          </div>
+          <TruncateData data={pm.receiverAddress} />
+          {pm.deeplinks.map((d) => (
+            <div key={d.app}>
+              <a className="text-violet-400" href={d.url}>
+                {d.label}
+              </a>
+            </div>
+          ))}
+          <button type="button" className="btn mt-2" onClick={() => reset()}>
+            Reset
+          </button>
+        </div>
+      )}
+
+      {error && <TruncateData data={error.message} className="text-red-500" />}
+    </div>
+  )
+}

--- a/examples/quickstarts/openfort-ui/src/components/cards/main.tsx
+++ b/examples/quickstarts/openfort-ui/src/components/cards/main.tsx
@@ -1,4 +1,5 @@
 import {
+  BanknotesIcon,
   HomeIcon,
   PencilIcon,
   PlayIcon,
@@ -9,6 +10,7 @@ import { useEffect, useState } from 'react'
 import { useAccount } from 'wagmi'
 import { DesktopTabGroup, MobileTabGroup, type TabType } from '../ui/Tabs'
 import { Actions } from './actions'
+import { Funding } from './funding'
 import { Head } from './head'
 import { Profile } from './profile'
 import { Sign } from './sign'
@@ -80,6 +82,11 @@ const tabs: TabType[] = [
     name: 'Wallets',
     component: <Wallets />,
     icon: WalletIcon,
+  },
+  {
+    name: 'Funding',
+    component: <Funding />,
+    icon: BanknotesIcon,
   },
 ]
 

--- a/examples/quickstarts/openfort-ui/src/components/providers.tsx
+++ b/examples/quickstarts/openfort-ui/src/components/providers.tsx
@@ -1,13 +1,13 @@
 import { OpenfortProvider, type Theme } from '@openfort/react'
 import { getDefaultConfig, OpenfortWagmiBridge } from '@openfort/react/wagmi'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { beamTestnet, polygonAmoy } from 'viem/chains'
+import { baseSepolia, polygonAmoy } from 'viem/chains'
 import { createConfig, WagmiProvider } from 'wagmi'
 
 const config = createConfig(
   getDefaultConfig({
     appName: 'Openfort React demo',
-    chains: [beamTestnet, polygonAmoy], // The chains you want to support
+    chains: [polygonAmoy, baseSepolia], // The chains you want to support
     walletConnectProjectId: import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID, // The WalletConnect Project ID
   }),
 )
@@ -28,6 +28,8 @@ const walletConfig = {
 
 const uiConfig = {
   theme: import.meta.env.VITE_OPENFORT_THEME as Theme,
+  // Point the Deposit hub's crypto/CEX rails at the local funding backend.
+  fundingBaseUrl: import.meta.env.VITE_FUNDING_BASE_URL ?? 'http://localhost:8787',
 }
 
 export function Providers({ children }: { children: React.ReactNode }) {

--- a/packages/openfort-react/src/__tests__/setup.ts
+++ b/packages/openfort-react/src/__tests__/setup.ts
@@ -9,3 +9,39 @@ vi.mock('../utils/logger', () => ({
     warn: vi.fn(),
   },
 }))
+
+// Under this vitest + jsdom combination, `localStorage`/`sessionStorage` land as
+// bare objects without the full Storage API (e.g. `clear`/`removeItem`). Install
+// a minimal, spec-shaped in-memory Storage so storage-dependent code and tests
+// behave like a browser.
+class MemoryStorage {
+  private store = new Map<string, string>()
+  get length(): number {
+    return this.store.size
+  }
+  clear(): void {
+    this.store.clear()
+  }
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null
+  }
+  removeItem(key: string): void {
+    this.store.delete(key)
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value))
+  }
+}
+
+for (const name of ['localStorage', 'sessionStorage'] as const) {
+  const existing = (globalThis as Record<string, unknown>)[name] as Storage | undefined
+  if (!existing || typeof existing.clear !== 'function') {
+    Object.defineProperty(globalThis, name, {
+      value: new MemoryStorage() as unknown as Storage,
+      configurable: true,
+    })
+  }
+}

--- a/packages/openfort-react/src/__tests__/useFunding.test.ts
+++ b/packages/openfort-react/src/__tests__/useFunding.test.ts
@@ -1,0 +1,171 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FundingClient } from '../hooks/openfort/fundingClient'
+import type { FundingSession, FundingTarget, PaymentMethodInput } from '../hooks/openfort/useFunding'
+
+// useFunding reads only uiConfig.fundingBaseUrl from useOpenfort; stub it so the
+// hook resolves no default client and we inject a mock instead.
+const mockUiConfig: { fundingBaseUrl?: string } = {}
+vi.mock('../components/Openfort/useOpenfort', () => ({
+  useOpenfort: () => ({ uiConfig: mockUiConfig }),
+}))
+
+const { useFunding } = await import('../hooks/openfort/useFunding')
+
+const target: FundingTarget = { chain: 'eip155:8453', currency: '0xUSDC', address: '0xdest' }
+const paymentMethod: PaymentMethodInput = {
+  type: 'evm',
+  source: { chain: 'eip155:137', currency: '0xsrc', amount: '1000000' },
+}
+
+function makeSession(over: Partial<FundingSession> = {}): FundingSession {
+  return {
+    id: 'fnd_1',
+    clientSecret: 'cs_1',
+    target,
+    status: 'requires_payment_method',
+    amountUnits: null,
+    metadata: null,
+    externalId: null,
+    createdAt: 0,
+    expiresAt: 0,
+    paymentMethod: null,
+    ...over,
+  }
+}
+
+function makeClient() {
+  const create = vi.fn()
+  const setPaymentMethod = vi.fn()
+  const get = vi.fn()
+  const payLink = vi.fn()
+  const client: FundingClient = { sessions: { create, setPaymentMethod, get }, payLink }
+  return { client, create, setPaymentMethod, get, payLink }
+}
+
+describe('useFunding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUiConfig.fundingBaseUrl = undefined
+  })
+
+  it('is unavailable and refuses to fund when no client is configured', async () => {
+    const { result } = renderHook(() => useFunding())
+    expect(result.current.isAvailable).toBe(false)
+    expect(result.current.status).toBe('idle')
+
+    await act(async () => {
+      await expect(result.current.fund(target, paymentMethod)).rejects.toThrow('not configured')
+    })
+    expect(result.current.error?.message).toMatch('not configured')
+  })
+
+  it('creates a session, sets the payment method, and surfaces a terminal status without polling', async () => {
+    const { client, create, setPaymentMethod, get } = makeClient()
+    create.mockResolvedValue(makeSession())
+    setPaymentMethod.mockResolvedValue(makeSession({ status: 'succeeded' }))
+
+    const { result } = renderHook(() => useFunding({ client }))
+    expect(result.current.isAvailable).toBe(true)
+
+    await act(async () => {
+      await result.current.fund(target, paymentMethod)
+    })
+
+    expect(create).toHaveBeenCalledWith({ target })
+    expect(setPaymentMethod).toHaveBeenCalledWith('fnd_1', { clientSecret: 'cs_1', paymentMethod })
+    expect(get).not.toHaveBeenCalled() // succeeded is terminal — no poll
+    expect(result.current.status).toBe('succeeded')
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('records an error when the backend call fails', async () => {
+    const { client, create } = makeClient()
+    create.mockRejectedValue(new Error('boom'))
+
+    const { result } = renderHook(() => useFunding({ client }))
+    await act(async () => {
+      await expect(result.current.fund(target, paymentMethod)).rejects.toThrow('boom')
+    })
+
+    expect(result.current.error?.message).toBe('boom')
+    expect(result.current.status).toBe('idle')
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('ignores a stale in-flight fund() when a newer one supersedes it', async () => {
+    const { client, create, setPaymentMethod } = makeClient()
+    create.mockResolvedValue(makeSession())
+
+    let releaseStale: (s: FundingSession) => void = () => {}
+    const stalePending = new Promise<FundingSession>((resolve) => {
+      releaseStale = resolve
+    })
+    setPaymentMethod
+      .mockImplementationOnce(() => stalePending) // first call hangs
+      .mockResolvedValueOnce(makeSession({ id: 'fresh', status: 'succeeded' }))
+
+    const { result } = renderHook(() => useFunding({ client }))
+
+    let stale: Promise<unknown> = Promise.resolve()
+    act(() => {
+      stale = result.current.fund(target, paymentMethod).catch(() => {})
+    })
+    await act(async () => {
+      await result.current.fund(target, paymentMethod) // newer call wins
+    })
+    expect(result.current.session?.id).toBe('fresh')
+
+    await act(async () => {
+      releaseStale(makeSession({ id: 'stale', status: 'bounced' }))
+      await stale
+    })
+    expect(result.current.session?.id).toBe('fresh') // stale resolution did not clobber state
+    expect(result.current.status).toBe('succeeded')
+  })
+
+  it('resolves a pay link through the client', async () => {
+    const { client, payLink } = makeClient()
+    payLink.mockResolvedValue('https://pay.example/checkout')
+
+    const { result } = renderHook(() => useFunding({ client }))
+    let url = ''
+    await act(async () => {
+      url = await result.current.payLink({
+        exchange: 'coinbase',
+        address: '0xdest',
+        asset: 'USDC',
+        chain: 'eip155:8453',
+      })
+    })
+
+    expect(url).toBe('https://pay.example/checkout')
+    expect(payLink).toHaveBeenCalledWith({
+      exchange: 'coinbase',
+      address: '0xdest',
+      asset: 'USDC',
+      chain: 'eip155:8453',
+    })
+  })
+
+  it('reset() returns the hook to idle', async () => {
+    const { client, create, setPaymentMethod } = makeClient()
+    create.mockResolvedValue(makeSession())
+    setPaymentMethod.mockResolvedValue(makeSession({ status: 'succeeded' }))
+
+    const { result } = renderHook(() => useFunding({ client }))
+    await act(async () => {
+      await result.current.fund(target, paymentMethod)
+    })
+    expect(result.current.session).not.toBeNull()
+
+    act(() => {
+      result.current.reset()
+    })
+    expect(result.current.session).toBeNull()
+    expect(result.current.status).toBe('idle')
+    expect(result.current.error).toBeNull()
+    expect(result.current.loading).toBe(false)
+  })
+})

--- a/packages/openfort-react/src/components/ConnectModal/index.tsx
+++ b/packages/openfort-react/src/components/ConnectModal/index.tsx
@@ -28,6 +28,9 @@ import ConnectedSuccess from '../Pages/ConnectedSuccess'
 import Connectors from '../Pages/Connectors'
 import CreateGuestUserPage from '../Pages/CreateGuestUserPage'
 import CreateWallet from '../Pages/CreateWallet'
+import Deposit from '../Pages/Deposit'
+import DepositCex from '../Pages/DepositCex'
+import DepositCrypto from '../Pages/DepositCrypto'
 import DownloadApp from '../Pages/DownloadApp'
 import EmailLogin from '../Pages/EmailLogin'
 import EmailOTP from '../Pages/EmailOTP'
@@ -99,6 +102,9 @@ function buildSharedPages(): RoutePages {
     buyProviderSelect: <BuyProviderSelect />,
     receive: <Receive />,
     buy: <Buy />,
+    deposit: <Deposit />,
+    depositCrypto: <DepositCrypto />,
+    depositCex: <DepositCex />,
     exportKey: <ExportKey />,
     walletOverview: <Connected />,
   }

--- a/packages/openfort-react/src/components/Openfort/types.ts
+++ b/packages/openfort-react/src/components/Openfort/types.ts
@@ -53,6 +53,9 @@ export const routes = {
   SEND_TOKEN_SELECT: 'sendTokenSelect',
   SEND_CONFIRMATION: 'sendConfirmation',
   RECEIVE: 'receive',
+  DEPOSIT: 'deposit',
+  DEPOSIT_CRYPTO: 'depositCrypto',
+  DEPOSIT_CEX: 'depositCex',
   BUY: 'buy',
   BUY_TOKEN_SELECT: 'buyTokenSelect',
   BUY_SELECT_PROVIDER: 'buySelectProvider',
@@ -353,6 +356,15 @@ export type ConnectUIOptions = {
   buyWithCardUrl?: string
   buyFromExchangeUrl?: string
   buyTroubleshootingUrl?: string
+  /**
+   * Base URL of the openfort-funding backend (e.g. `https://funding.openfort.io`).
+   * Powers the Deposit hub's crypto/CEX rails (session API). When omitted, those
+   * rails are unavailable and the network layer is a no-op.
+   *
+   * TODO(openfort-funding-backend): default this from the platform config once the
+   * backend ships, so integrators don't have to set it manually.
+   */
+  fundingBaseUrl?: string
   phoneConfig?: PhoneConfig
   customPageComponents?: {
     [key in CustomizableRoutes]?: React.ReactElement
@@ -399,6 +411,8 @@ export type OpenfortUIOptionsExtended = {
   buyWithCardUrl?: string
   buyFromExchangeUrl?: string
   buyTroubleshootingUrl?: string
+  /** Base URL of the openfort-funding backend. See {@link ConnectUIOptions.fundingBaseUrl}. */
+  fundingBaseUrl?: string
   walletRecovery: WalletRecoveryOptionsExtended
   phoneConfig?: PhoneConfig
   customPageComponents?: {

--- a/packages/openfort-react/src/components/Pages/Connected/EthereumConnected.tsx
+++ b/packages/openfort-react/src/components/Pages/Connected/EthereumConnected.tsx
@@ -8,11 +8,10 @@
  */
 
 import { ChainTypeEnum } from '@openfort/openfort-js'
-import { AnimatePresence, motion } from 'framer-motion'
 import type React from 'react'
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
+import { lazy, Suspense, useEffect, useMemo } from 'react'
 import { formatUnits } from 'viem'
-import { BuyIcon, ReceiveIcon, SendIcon, UserRoundIcon } from '../../../assets/icons'
+import { ReceiveIcon, SendIcon, UserRoundIcon } from '../../../assets/icons'
 import { useEthereumEmbeddedWallet } from '../../../ethereum/hooks/useEthereumEmbeddedWallet'
 import { useEthereumWalletAssets } from '../../../ethereum/hooks/useEthereumWalletAssets'
 import { useEthereumBridge } from '../../../ethereum/OpenfortEthereumBridgeContext'
@@ -26,7 +25,6 @@ import Button from '../../Common/Button'
 import { TextLinkButton } from '../../Common/Button/styles'
 import Chain from '../../Common/Chain'
 import { CopyText } from '../../Common/CopyToClipboard/CopyText'
-import { ModalBody } from '../../Common/Modal/styles'
 import { useThemeContext } from '../../ConnectKitThemeProvider/ConnectKitThemeProvider'
 import { defaultSendFormState, routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
@@ -102,28 +100,9 @@ const EthereumConnected: React.FC = () => {
     }
   }, [isConnected, refetch])
 
-  const isTestnet = chain?.testnet ?? false
-  const [showTestnetMessage, setShowTestnetMessage] = useState(false)
-
   useEffect(() => {
     context.triggerResize()
-
-    if (showTestnetMessage) {
-      const timer = setTimeout(() => {
-        setShowTestnetMessage(false)
-      }, 2000)
-      return () => clearTimeout(timer)
-    }
-  }, [showTestnetMessage, context.triggerResize])
-
-  const handleBuyClick = (e: React.MouseEvent) => {
-    if (!chain || isTestnet) {
-      e.preventDefault()
-      setShowTestnetMessage(true)
-    } else {
-      context.setRoute(routes.BUY)
-    }
-  }
+  }, [context.triggerResize])
 
   useEffect(() => {
     if (!address) {
@@ -247,37 +226,14 @@ const EthereumConnected: React.FC = () => {
             >
               Send
             </ActionButton>
-            <ActionButton icon={<ReceiveIcon />} onClick={() => context.setRoute(routes.RECEIVE)}>
-              Get
-            </ActionButton>
-            <ActionButton
-              icon={<BuyIcon />}
-              onClick={handleBuyClick}
-              style={isTestnet ? { cursor: 'not-allowed', opacity: 0.4, pointerEvents: 'auto' } : undefined}
-            >
-              Buy
+            <ActionButton icon={<ReceiveIcon />} onClick={() => context.setRoute(routes.DEPOSIT)}>
+              Deposit
             </ActionButton>
           </>
         }
         hideBalance={context?.uiConfig.hideBalance}
         isBalanceLoading={isLoading}
         noWalletFallback={noWalletFallback}
-        afterActions={
-          <AnimatePresence onExitComplete={() => context.triggerResize()}>
-            {showTestnetMessage && (
-              <ModalBody
-                as={motion.div}
-                initial={{ opacity: 0, y: -10 }}
-                animate={{ opacity: 0.7, y: 0 }}
-                exit={{ opacity: 0, y: -10 }}
-                transition={{ duration: 0.2 }}
-                style={{ marginTop: 12, fontSize: 14, textAlign: 'center' }}
-              >
-                Buy is only available on mainnet chains
-              </ModalBody>
-            )}
-          </AnimatePresence>
-        }
       />
     </PageContent>
   )

--- a/packages/openfort-react/src/components/Pages/Deposit/AssetChainLogo.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/AssetChainLogo.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import type { SyntheticEvent } from 'react'
+
+const hide = (e: SyntheticEvent<HTMLImageElement>) => {
+  e.currentTarget.style.display = 'none'
+}
+
+/**
+ * Center logo for the deposit QR: the asset logo with the chain logo as a small
+ * badge bottom-left, so scanners can confirm the right token + network at a glance.
+ * Sized in % so it fills CustomQRCode's logo slot.
+ */
+export function AssetChainLogo({ assetLogo, chainLogo }: { assetLogo: string; chainLogo: string }) {
+  return (
+    <div style={{ position: 'relative', width: '100%' }}>
+      <img src={assetLogo} alt="" onError={hide} style={{ display: 'block', width: '100%', borderRadius: '50%' }} />
+      <img
+        src={chainLogo}
+        alt=""
+        onError={hide}
+        style={{
+          position: 'absolute',
+          bottom: '-8%',
+          left: '-8%',
+          width: '48%',
+          borderRadius: '50%',
+          border: '2px solid #fff',
+          background: '#fff',
+        }}
+      />
+    </div>
+  )
+}

--- a/packages/openfort-react/src/components/Pages/Deposit/Details.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/Details.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { PaymentMethod } from '../../../hooks/openfort/useFunding'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+import { chevron, detailsBox, detailsLabel, detailsRow, detailsToggle, detailsValue } from './formStyles'
+import { formatUnits6 } from './sources'
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={detailsRow}>
+      <span style={detailsLabel}>{label}</span>
+      <span style={detailsValue}>{value}</span>
+    </div>
+  )
+}
+
+/** Collapsible details: minimum, Relay fee, processing time, max deposit. */
+export function DepositDetails({ pm, token }: { pm: PaymentMethod; token: string }) {
+  const [open, setOpen] = useState(false)
+  const { triggerResize } = useOpenfort()
+  // Grow/shrink the modal to fit the expanded rows.
+  useEffect(() => {
+    triggerResize()
+  }, [open, triggerResize])
+  const relayFee = pm.fees.find((f) => f.kind === 'relayerService')
+  const feeText = relayFee ? `≈ ${formatUnits6(relayFee.amount)} ${relayFee.currency}` : '—'
+
+  return (
+    <div style={detailsBox}>
+      <button type="button" style={detailsToggle} onClick={() => setOpen((o) => !o)}>
+        <span>Details</span>
+        <span style={chevron}>{open ? '▴' : '▾'}</span>
+      </button>
+      {open && (
+        <div>
+          <Row label="Minimum" value={relayFee ? `above ${formatUnits6(relayFee.amount)} ${token}` : '~0.10'} />
+          <Row label="Relay fee" value={feeText} />
+          <Row label="Processing time" value="< 1 min" />
+          <Row label="Max deposit" value="Unlimited" />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/openfort-react/src/components/Pages/Deposit/Details.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/Details.tsx
@@ -16,7 +16,7 @@ function Row({ label, value }: { label: string; value: string }) {
 }
 
 /** Collapsible details: minimum, Relay fee, processing time, max deposit. */
-export function DepositDetails({ pm, token }: { pm: PaymentMethod; token: string }) {
+export function DepositDetails({ pm }: { pm: PaymentMethod }) {
   const [open, setOpen] = useState(false)
   const { triggerResize } = useOpenfort()
   // Grow/shrink the modal to fit the expanded rows.
@@ -34,7 +34,7 @@ export function DepositDetails({ pm, token }: { pm: PaymentMethod; token: string
       </button>
       {open && (
         <div>
-          <Row label="Minimum" value={relayFee ? `above ${formatUnits6(relayFee.amount)} ${token}` : '~0.10'} />
+          <Row label="Minimum transfer" value="$0.25" />
           <Row label="Relay fee" value={feeText} />
           <Row label="Processing time" value="< 1 min" />
           <Row label="Max deposit" value="Unlimited" />

--- a/packages/openfort-react/src/components/Pages/Deposit/OrDivider.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/OrDivider.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { orLine, orRow, orText } from './formStyles'
+
+/** Separates the scan-QR / copy-address path from the open-wallet / open-exchange path. */
+export function OrDivider() {
+  return (
+    <div style={orRow}>
+      <span style={orLine} />
+      <span style={orText}>or</span>
+      <span style={orLine} />
+    </div>
+  )
+}

--- a/packages/openfort-react/src/components/Pages/Deposit/formStyles.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/formStyles.ts
@@ -4,15 +4,6 @@ import type { CSSProperties } from 'react'
 
 export const field: CSSProperties = { display: 'grid', gap: 6, fontSize: 13, textAlign: 'left' }
 
-export const control: CSSProperties = {
-  padding: '8px 10px',
-  borderRadius: 8,
-  fontSize: 14,
-  border: '1px solid var(--ck-body-divider, #e4e4e7)',
-  background: 'var(--ck-body-background-secondary, #fafafa)',
-  color: 'inherit',
-}
-
 /** A control-styled box holding a logo + a borderless select. */
 export const selectWrap: CSSProperties = {
   display: 'flex',
@@ -38,8 +29,6 @@ export const bareSelect: CSSProperties = {
 export const logoImg: CSSProperties = { width: 20, height: 20, borderRadius: '50%', flexShrink: 0 }
 
 export const codeStyle: CSSProperties = { fontSize: 12, wordBreak: 'break-all' }
-
-export const rowCenter: CSSProperties = { display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }
 
 /** Shadow card around the deposit address + copy button. */
 export const addressBox: CSSProperties = {

--- a/packages/openfort-react/src/components/Pages/Deposit/formStyles.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/formStyles.ts
@@ -1,0 +1,110 @@
+import type { CSSProperties } from 'react'
+
+/** Shared inline styles for the Deposit crypto/exchange forms (ConnectKit CSS vars). */
+
+export const field: CSSProperties = { display: 'grid', gap: 6, fontSize: 13, textAlign: 'left' }
+
+export const control: CSSProperties = {
+  padding: '8px 10px',
+  borderRadius: 8,
+  fontSize: 14,
+  border: '1px solid var(--ck-body-divider, #e4e4e7)',
+  background: 'var(--ck-body-background-secondary, #fafafa)',
+  color: 'inherit',
+}
+
+/** A control-styled box holding a logo + a borderless select. */
+export const selectWrap: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '8px 10px',
+  borderRadius: 8,
+  border: '1px solid var(--ck-body-divider, #e4e4e7)',
+  background: 'var(--ck-body-background-secondary, #fafafa)',
+}
+
+// Native select keeps its dropdown arrow (no appearance:none).
+export const bareSelect: CSSProperties = {
+  flex: 1,
+  border: 'none',
+  background: 'transparent',
+  color: 'inherit',
+  fontSize: 14,
+  outline: 'none',
+  cursor: 'pointer',
+}
+
+export const logoImg: CSSProperties = { width: 20, height: 20, borderRadius: '50%', flexShrink: 0 }
+
+export const codeStyle: CSSProperties = { fontSize: 12, wordBreak: 'break-all' }
+
+export const rowCenter: CSSProperties = { display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }
+
+/** Chain + token selectors side by side. */
+export const twoCol: CSSProperties = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginTop: 12 }
+
+/** Wrapping row of wallet deeplink buttons at the bottom of the crypto flow. */
+export const deeplinkRow: CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 16 }
+
+/** Themed (secondary-button) deeplink button — matches the hub options, visible in both modes. */
+export const deeplinkBtn: CSSProperties = {
+  flex: '1 1 130px',
+  textAlign: 'center',
+  padding: '10px 12px',
+  borderRadius: 10,
+  fontSize: 13,
+  fontWeight: 600,
+  textDecoration: 'none',
+  background: 'var(--ck-secondary-button-background, #f3f3f5)',
+  color: 'var(--ck-body-color, #1a1a2e)',
+  border: '1px solid var(--ck-body-divider, #e4e4e7)',
+}
+
+/** Full-width wallet row for the one-column "Transfer crypto from wallet" sub-page. */
+export const walletListBtn: CSSProperties = {
+  display: 'block',
+  width: '100%',
+  boxSizing: 'border-box',
+  textAlign: 'center',
+  padding: '14px 16px',
+  borderRadius: 10,
+  fontSize: 14,
+  fontWeight: 600,
+  textDecoration: 'none',
+  background: 'var(--ck-secondary-button-background, #f3f3f5)',
+  color: 'var(--ck-body-color, #1a1a2e)',
+  border: '1px solid var(--ck-body-divider, #e4e4e7)',
+}
+
+/** Collapsible "Details" panel (min / fee / processing / max). */
+export const detailsBox: CSSProperties = {
+  marginTop: 14,
+  borderTop: '1px solid var(--ck-body-divider, #ededed)',
+  paddingTop: 6,
+}
+
+export const detailsToggle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+  background: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+  padding: '6px 0',
+  color: 'var(--ck-body-color, #1a1a2e)',
+  fontSize: 14,
+  fontWeight: 600,
+}
+
+export const detailsRow: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  padding: '4px 0',
+  fontSize: 13,
+}
+
+export const detailsLabel: CSSProperties = { color: 'var(--ck-body-color-muted, #6b7280)' }
+export const detailsValue: CSSProperties = { color: 'var(--ck-body-color, #1a1a2e)' }
+export const chevron: CSSProperties = { color: 'var(--ck-body-color-muted, #6b7280)', fontSize: 12 }

--- a/packages/openfort-react/src/components/Pages/Deposit/formStyles.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/formStyles.ts
@@ -41,6 +41,25 @@ export const codeStyle: CSSProperties = { fontSize: 12, wordBreak: 'break-all' }
 
 export const rowCenter: CSSProperties = { display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }
 
+/** Shadow card around the deposit address + copy button. */
+export const addressBox: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 8,
+  marginTop: 12,
+  padding: '12px 14px',
+  borderRadius: 12,
+  background: 'var(--ck-body-background, #fff)',
+  border: '1px solid var(--ck-body-divider, #ededed)',
+  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.06)',
+}
+
+/** "──  or  ──" separator between the scan/copy path and the open-wallet path. */
+export const orRow: CSSProperties = { display: 'flex', alignItems: 'center', gap: 10, margin: '16px 0 4px' }
+export const orLine: CSSProperties = { flex: 1, height: 1, background: 'var(--ck-body-divider, #ededed)' }
+export const orText: CSSProperties = { fontSize: 12, fontWeight: 500, color: 'var(--ck-body-color-muted, #6b7280)' }
+
 /** Chain + token selectors side by side. */
 export const twoCol: CSSProperties = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginTop: 12 }
 
@@ -80,8 +99,6 @@ export const walletListBtn: CSSProperties = {
 /** Collapsible "Details" panel (min / fee / processing / max). */
 export const detailsBox: CSSProperties = {
   marginTop: 14,
-  borderTop: '1px solid var(--ck-body-divider, #ededed)',
-  paddingTop: 6,
 }
 
 export const detailsToggle: CSSProperties = {

--- a/packages/openfort-react/src/components/Pages/Deposit/index.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/index.tsx
@@ -14,7 +14,7 @@ import { DepositContent, OptionButton, OptionInfo, OptionList, OptionSubtitle, O
  * new funding-session Pages; fiat rows reuse the existing Buy flow.
  */
 const Deposit = () => {
-  const { setRoute } = useOpenfort()
+  const { setRoute, setBuyForm } = useOpenfort()
   const isMobile = useIsMobile()
   const { isAvailable } = useFunding()
 
@@ -29,9 +29,9 @@ const Deposit = () => {
       setRoute(routes.DEPOSIT_CEX)
       return
     }
-    // Fiat rails reuse the existing Buy flow.
-    // TODO(openfort-funding-backend): preselect the rail (target.providerId) on buyForm
-    // before routing, so Apple Pay / Card land on the right provider.
+    // Fiat rails reuse the existing Buy flow; preselect the chosen provider so
+    // Apple Pay / Card land on the right rail.
+    setBuyForm((prev) => ({ ...prev, providerId: target.providerId }))
     setRoute(routes.BUY)
   }
 

--- a/packages/openfort-react/src/components/Pages/Deposit/index.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/index.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useFunding } from '../../../hooks/openfort/useFunding'
+import useIsMobile from '../../../hooks/useIsMobile'
+import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
+import { routes } from '../../Openfort/types'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+import { PageContent } from '../../PageContent'
+import { type DepositMethodTarget, getPaymentOptions } from './paymentOptions'
+import { DepositContent, OptionButton, OptionInfo, OptionList, OptionSubtitle, OptionTitle } from './styles'
+
+/**
+ * Deposit hub — one entry point, a method selector. Crypto/CEX route into the
+ * new funding-session Pages; fiat rows reuse the existing Buy flow.
+ */
+const Deposit = () => {
+  const { setRoute } = useOpenfort()
+  const isMobile = useIsMobile()
+  const { isAvailable } = useFunding()
+
+  const options = getPaymentOptions({ isMobile, fundingAvailable: isAvailable })
+
+  const go = (target: DepositMethodTarget) => {
+    if (target.kind === 'crypto') {
+      setRoute(routes.DEPOSIT_CRYPTO)
+      return
+    }
+    if (target.kind === 'cex') {
+      setRoute(routes.DEPOSIT_CEX)
+      return
+    }
+    // Fiat rails reuse the existing Buy flow.
+    // TODO(openfort-funding-backend): preselect the rail (target.providerId) on buyForm
+    // before routing, so Apple Pay / Card land on the right provider.
+    setRoute(routes.BUY)
+  }
+
+  return (
+    <PageContent onBack={routes.CONNECTED}>
+      <ModalHeading>Add funds</ModalHeading>
+      <ModalBody>Choose how you'd like to deposit.</ModalBody>
+      <DepositContent>
+        <OptionList>
+          {options.map((option) => (
+            <OptionButton key={option.id} type="button" disabled={option.disabled} onClick={() => go(option.target)}>
+              <OptionInfo>
+                <OptionTitle>{option.title}</OptionTitle>
+                <OptionSubtitle>{option.disabledReason ?? option.subtitle}</OptionSubtitle>
+              </OptionInfo>
+            </OptionButton>
+          ))}
+        </OptionList>
+      </DepositContent>
+    </PageContent>
+  )
+}
+
+export default Deposit

--- a/packages/openfort-react/src/components/Pages/Deposit/paymentOptions.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/paymentOptions.ts
@@ -1,0 +1,100 @@
+import type { BuyProviderId } from '../../Openfort/types'
+
+/** The deposit methods surfaced in the hub. */
+export type DepositMethodId = 'applePay' | 'card' | 'crypto' | 'cex'
+
+/**
+ * What a row routes into:
+ * - `buy`: the existing fiat onramp flow, with a rail (provider) preselected.
+ * - `crypto` / `cex`: the new funding-session Pages.
+ */
+export type DepositMethodTarget = { kind: 'buy'; providerId: BuyProviderId } | { kind: 'crypto' } | { kind: 'cex' }
+
+export type DepositMethod = {
+  id: DepositMethodId
+  title: string
+  /** Speed/fee hint, e.g. "instant, ~4% fee". */
+  subtitle: string
+  target: DepositMethodTarget
+  /** Only show on mobile devices (e.g. Apple Pay). */
+  mobileOnly?: boolean
+}
+
+/** Context used to order/filter the rows for the current device + region. */
+export type PaymentOptionsContext = {
+  isMobile: boolean
+  /** When the funding backend is unavailable, crypto/CEX rows are disabled. */
+  fundingAvailable: boolean
+  /**
+   * ISO-3166 region of the user, when known. Used to disable region-blocked
+   * rails with a reason.
+   * TODO(openfort-funding-backend): source this from the platform/geo config.
+   */
+  region?: string | null
+}
+
+/** A row ready to render: resolved order, plus disabled state + reason. */
+export type ResolvedDepositOption = DepositMethod & {
+  disabled: boolean
+  disabledReason?: string
+}
+
+const ALL_METHODS: DepositMethod[] = [
+  {
+    id: 'applePay',
+    title: 'Apple Pay',
+    subtitle: 'instant',
+    target: { kind: 'buy', providerId: 'stripe' },
+    mobileOnly: true,
+  },
+  {
+    id: 'card',
+    title: 'Card',
+    subtitle: 'instant, ~4% fee',
+    target: { kind: 'buy', providerId: 'stripe' },
+  },
+  {
+    id: 'crypto',
+    title: 'Transfer crypto',
+    subtitle: 'from any chain',
+    target: { kind: 'crypto' },
+  },
+  {
+    id: 'cex',
+    title: 'Transfer from Exchange',
+    subtitle: 'Binance, Coinbase',
+    target: { kind: 'cex' },
+  },
+]
+
+// TODO(openfort-funding-backend): drive region blocks from a server-provided
+// availability map instead of this placeholder (no rails are blocked yet).
+const REGION_BLOCKED: Partial<Record<DepositMethodId, string[]>> = {}
+
+function isRegionBlocked(method: DepositMethod, region?: string | null): boolean {
+  if (!region) return false
+  return REGION_BLOCKED[method.id]?.includes(region) ?? false
+}
+
+/**
+ * Resolve the deposit rows for the current context: filter device-incompatible
+ * rails, order them (Apple Pay first on mobile), and mark disabled rows with a
+ * reason.
+ */
+export function getPaymentOptions(ctx: PaymentOptionsContext): ResolvedDepositOption[] {
+  const visible = ALL_METHODS.filter((m) => (m.mobileOnly ? ctx.isMobile : true))
+
+  const ordered = ctx.isMobile
+    ? [...visible].sort((a, b) => Number(b.id === 'applePay') - Number(a.id === 'applePay'))
+    : visible
+
+  return ordered.map((method) => {
+    if (isRegionBlocked(method, ctx.region)) {
+      return { ...method, disabled: true, disabledReason: 'Not available in your region' }
+    }
+    if ((method.target.kind === 'crypto' || method.target.kind === 'cex') && !ctx.fundingAvailable) {
+      return { ...method, disabled: true, disabledReason: 'Coming soon' }
+    }
+    return { ...method, disabled: false }
+  })
+}

--- a/packages/openfort-react/src/components/Pages/Deposit/paymentOptions.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/paymentOptions.ts
@@ -1,7 +1,7 @@
 import type { BuyProviderId } from '../../Openfort/types'
 
 /** The deposit methods surfaced in the hub. */
-export type DepositMethodId = 'applePay' | 'card' | 'crypto' | 'cex'
+type DepositMethodId = 'applePay' | 'card' | 'crypto' | 'cex'
 
 /**
  * What a row routes into:
@@ -10,7 +10,7 @@ export type DepositMethodId = 'applePay' | 'card' | 'crypto' | 'cex'
  */
 export type DepositMethodTarget = { kind: 'buy'; providerId: BuyProviderId } | { kind: 'crypto' } | { kind: 'cex' }
 
-export type DepositMethod = {
+type DepositMethod = {
   id: DepositMethodId
   title: string
   /** Speed/fee hint, e.g. "instant, ~4% fee". */
@@ -21,7 +21,7 @@ export type DepositMethod = {
 }
 
 /** Context used to order/filter the rows for the current device + region. */
-export type PaymentOptionsContext = {
+type PaymentOptionsContext = {
   isMobile: boolean
   /** When the funding backend is unavailable, crypto/CEX rows are disabled. */
   fundingAvailable: boolean
@@ -34,7 +34,7 @@ export type PaymentOptionsContext = {
 }
 
 /** A row ready to render: resolved order, plus disabled state + reason. */
-export type ResolvedDepositOption = DepositMethod & {
+type ResolvedDepositOption = DepositMethod & {
   disabled: boolean
   disabledReason?: string
 }

--- a/packages/openfort-react/src/components/Pages/Deposit/sources.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/sources.ts
@@ -4,9 +4,9 @@
  * would source these from a server-provided token registry.
  */
 
-export const SOLANA_CHAIN = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+const SOLANA_CHAIN = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
 
-export type SourceChain = { id: string; name: string; logo: string }
+type SourceChain = { id: string; name: string; logo: string }
 
 export const SOURCE_CHAINS: SourceChain[] = [
   { id: 'eip155:137', name: 'Polygon', logo: 'https://icons.llamao.fi/icons/chains/rsz_polygon.jpg' },
@@ -19,13 +19,13 @@ export const SOURCE_CHAINS: SourceChain[] = [
 const USDC_LOGO = 'https://assets.coingecko.com/coins/images/6319/small/usdc.png'
 const USDT_LOGO = 'https://assets.coingecko.com/coins/images/325/small/Tether.png'
 
-export type TokenInfo = { symbol: string; address: string; logo: string }
+type TokenInfo = { symbol: string; address: string; logo: string }
 
 const usdc = (address: string): TokenInfo => ({ symbol: 'USDC', address, logo: USDC_LOGO })
 const usdt = (address: string): TokenInfo => ({ symbol: 'USDT', address, logo: USDT_LOGO })
 
 /** Mainnet USDC/USDT contracts per supported source chain. */
-export const TOKENS_BY_CHAIN: Record<string, TokenInfo[]> = {
+const TOKENS_BY_CHAIN: Record<string, TokenInfo[]> = {
   'eip155:137': [
     usdc('0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'),
     usdt('0xc2132D05D31c914a87C6611C10748AEb04B58e8F'),
@@ -45,9 +45,6 @@ export const TOKENS_BY_CHAIN: Record<string, TokenInfo[]> = {
   ],
 }
 
-/** Exchanges offered in the "transfer from an exchange" flow. */
-export const EXCHANGES = ['binance', 'coinbase'] as const
-
 /** Destination for the demo: USDC on Base. */
 export const DEST_CHAIN = 'eip155:8453'
 export const DEST_USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
@@ -62,7 +59,7 @@ export function tokensFor(chain: string): TokenInfo[] {
   return TOKENS_BY_CHAIN[chain] ?? []
 }
 
-export function tokenInfo(chain: string, symbol: string): TokenInfo | undefined {
+function tokenInfo(chain: string, symbol: string): TokenInfo | undefined {
   return tokensFor(chain).find((t) => t.symbol === symbol)
 }
 
@@ -76,10 +73,6 @@ export function chainLogo(id: string): string {
 
 export function tokenLogo(chain: string, symbol: string): string {
   return tokenInfo(chain, symbol)?.logo ?? USDC_LOGO
-}
-
-export function chainName(id: string): string {
-  return SOURCE_CHAINS.find((c) => c.id === id)?.name ?? id
 }
 
 export function isSolana(chain: string): boolean {

--- a/packages/openfort-react/src/components/Pages/Deposit/sources.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/sources.ts
@@ -1,0 +1,94 @@
+/**
+ * Curated source assets for the demo deposit flow — USDC/USDT across a few EVM
+ * chains plus Solana, with logos and the fixed destination. A production build
+ * would source these from a server-provided token registry.
+ */
+
+export const SOLANA_CHAIN = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+
+export type SourceChain = { id: string; name: string; logo: string }
+
+export const SOURCE_CHAINS: SourceChain[] = [
+  { id: 'eip155:137', name: 'Polygon', logo: 'https://icons.llamao.fi/icons/chains/rsz_polygon.jpg' },
+  { id: 'eip155:42161', name: 'Arbitrum', logo: 'https://icons.llamao.fi/icons/chains/rsz_arbitrum.jpg' },
+  { id: 'eip155:8453', name: 'Base', logo: 'https://icons.llamao.fi/icons/chains/rsz_base.jpg' },
+  { id: 'eip155:10', name: 'Optimism', logo: 'https://icons.llamao.fi/icons/chains/rsz_optimism.jpg' },
+  { id: SOLANA_CHAIN, name: 'Solana', logo: 'https://icons.llamao.fi/icons/chains/rsz_solana.jpg' },
+]
+
+const USDC_LOGO = 'https://assets.coingecko.com/coins/images/6319/small/usdc.png'
+const USDT_LOGO = 'https://assets.coingecko.com/coins/images/325/small/Tether.png'
+
+export type TokenInfo = { symbol: string; address: string; logo: string }
+
+const usdc = (address: string): TokenInfo => ({ symbol: 'USDC', address, logo: USDC_LOGO })
+const usdt = (address: string): TokenInfo => ({ symbol: 'USDT', address, logo: USDT_LOGO })
+
+/** Mainnet USDC/USDT contracts per supported source chain. */
+export const TOKENS_BY_CHAIN: Record<string, TokenInfo[]> = {
+  'eip155:137': [
+    usdc('0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'),
+    usdt('0xc2132D05D31c914a87C6611C10748AEb04B58e8F'),
+  ],
+  'eip155:42161': [
+    usdc('0xaf88d065e77c8cC2239327C5EDb3A432268e5831'),
+    usdt('0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9'),
+  ],
+  'eip155:8453': [
+    usdc('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'),
+    usdt('0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2'),
+  ],
+  'eip155:10': [usdc('0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'), usdt('0x94b008aA00579c1307B0EF2c499aD98a8ce58e58')],
+  [SOLANA_CHAIN]: [
+    usdc('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+    usdt('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'),
+  ],
+}
+
+/** Exchanges offered in the "transfer from an exchange" flow. */
+export const EXCHANGES = ['binance', 'coinbase'] as const
+
+/** Destination for the demo: USDC on Base. */
+export const DEST_CHAIN = 'eip155:8453'
+export const DEST_USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+
+/**
+ * Nominal amount used only to fetch an *open* (reusable) deposit address — the
+ * address is route-bound, so it stays valid for any amount above the minimum.
+ */
+export const NOMINAL_UNITS = '10000000'
+
+export function tokensFor(chain: string): TokenInfo[] {
+  return TOKENS_BY_CHAIN[chain] ?? []
+}
+
+export function tokenInfo(chain: string, symbol: string): TokenInfo | undefined {
+  return tokensFor(chain).find((t) => t.symbol === symbol)
+}
+
+export function addressFor(chain: string, symbol: string): string {
+  return tokenInfo(chain, symbol)?.address ?? DEST_USDC
+}
+
+export function chainLogo(id: string): string {
+  return SOURCE_CHAINS.find((c) => c.id === id)?.logo ?? ''
+}
+
+export function tokenLogo(chain: string, symbol: string): string {
+  return tokenInfo(chain, symbol)?.logo ?? USDC_LOGO
+}
+
+export function chainName(id: string): string {
+  return SOURCE_CHAINS.find((c) => c.id === id)?.name ?? id
+}
+
+export function isSolana(chain: string): boolean {
+  return chain.startsWith('solana:')
+}
+
+/** Format a 6-decimal (USDC/USDT) base-unit amount as a human string. */
+export function formatUnits6(units: string): string {
+  const n = Number(units) / 1_000_000
+  if (!Number.isFinite(n)) return units
+  return n % 1 === 0 ? String(n) : n.toFixed(2)
+}

--- a/packages/openfort-react/src/components/Pages/Deposit/styles.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/styles.ts
@@ -1,0 +1,75 @@
+import styled from '../../../styles/styled'
+
+export const DepositContent = styled.div`
+  min-height: 360px;
+  display: flex;
+  flex-direction: column;
+`
+
+export const OptionList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 16px;
+`
+
+export const OptionButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 64px;
+  box-sizing: border-box;
+  padding: 14px 16px;
+  border-radius: var(--ck-secondary-button-border-radius);
+  border: 1px solid var(--ck-body-divider);
+  background: var(--ck-secondary-button-background);
+  color: var(--ck-body-color);
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease, color 150ms ease, opacity 150ms ease;
+  text-align: left;
+
+  &:hover:not(:disabled) {
+    background: var(--ck-secondary-button-hover-background);
+    border-color: var(--ck-body-color-muted);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`
+
+export const OptionInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow: hidden;
+`
+
+export const OptionTitle = styled.span`
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ck-body-color);
+`
+
+export const OptionSubtitle = styled.span`
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ck-body-color-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
+
+/** Sized, centered wrapper so the QR (which sizes off its parent width) renders. */
+export const QRWrapper = styled.div`
+  display: block;
+  margin: 14px auto;
+  width: 100%;
+  max-width: 300px;
+
+  > div {
+    width: 100%;
+  }
+`

--- a/packages/openfort-react/src/components/Pages/DepositCex/index.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositCex/index.tsx
@@ -13,16 +13,17 @@ import { PageContent } from '../../PageContent'
 import { AssetChainLogo } from '../Deposit/AssetChainLogo'
 import { DepositDetails } from '../Deposit/Details'
 import {
+  addressBox,
   bareSelect,
   codeStyle,
   deeplinkBtn,
   deeplinkRow,
   field,
   logoImg,
-  rowCenter,
   selectWrap,
   twoCol,
 } from '../Deposit/formStyles'
+import { OrDivider } from '../Deposit/OrDivider'
 import {
   addressFor,
   chainLogo,
@@ -147,15 +148,16 @@ const DepositCex = () => {
               imageBackground="#fff"
             />
           </QRWrapper>
-          <div style={rowCenter}>
+          <div style={addressBox}>
             <code style={codeStyle}>{receiverAddress}</code>
             <CopyIconButton value={receiverAddress} />
           </div>
-          {!sameChain && pm && <DepositDetails pm={pm} token={activeToken} />}
+          {!sameChain && pm && <DepositDetails pm={pm} />}
+          <OrDivider />
           <div style={deeplinkRow}>
             {PAY_EXCHANGES.map((ex) => (
               <button key={ex} type="button" style={deeplinkBtn} onClick={() => openPay(ex)}>
-                Open on {titleCase(ex)} ↗
+                Open {titleCase(ex)} ↗
               </button>
             ))}
           </div>

--- a/packages/openfort-react/src/components/Pages/DepositCex/index.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositCex/index.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import type { SyntheticEvent } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { useEthereumEmbeddedWallet } from '../../../ethereum/hooks/useEthereumEmbeddedWallet'
+import { useFunding } from '../../../hooks/openfort/useFunding'
+import { CopyIconButton } from '../../Common/CopyToClipboard/CopyIconButton'
+import CustomQRCode from '../../Common/CustomQRCode'
+import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
+import { routes } from '../../Openfort/types'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+import { PageContent } from '../../PageContent'
+import { AssetChainLogo } from '../Deposit/AssetChainLogo'
+import { DepositDetails } from '../Deposit/Details'
+import {
+  bareSelect,
+  codeStyle,
+  deeplinkBtn,
+  deeplinkRow,
+  field,
+  logoImg,
+  rowCenter,
+  selectWrap,
+  twoCol,
+} from '../Deposit/formStyles'
+import {
+  addressFor,
+  chainLogo,
+  DEST_CHAIN,
+  DEST_USDC,
+  isSolana,
+  NOMINAL_UNITS,
+  SOURCE_CHAINS,
+  tokenLogo,
+  tokensFor,
+} from '../Deposit/sources'
+import { QRWrapper } from '../Deposit/styles'
+
+// Exchanges withdraw to EVM networks here; Solana CEX withdrawal isn't profiled yet.
+const CEX_CHAINS = SOURCE_CHAINS.filter((c) => !isSolana(c.id))
+const PAY_EXCHANGES = ['coinbase', 'binance'] as const
+
+const hideBrokenLogo = (e: SyntheticEvent<HTMLImageElement>) => {
+  e.currentTarget.style.display = 'none'
+}
+
+function titleCase(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+/**
+ * Transfer from Exchange — choose a network + token to get a deposit address you
+ * can withdraw to from any exchange, plus one-tap Coinbase Pay / Binance Pay.
+ */
+const DepositCex = () => {
+  const wallet = useEthereumEmbeddedWallet()
+  const { triggerResize } = useOpenfort()
+  const { session, error, loading, isAvailable, fund, payLink, reset } = useFunding()
+  const address = wallet.status === 'connected' ? wallet.address : undefined
+  const firstChain = CEX_CHAINS[0]?.id ?? DEST_CHAIN
+  const [chain, setChain] = useState(firstChain)
+  const [token, setToken] = useState(tokensFor(firstChain)[0]?.symbol ?? 'USDC')
+  const pm = session?.paymentMethod ?? null
+  const lastKey = useRef('')
+
+  const tokens = tokensFor(chain)
+  const activeToken = tokens.some((t) => t.symbol === token) ? token : (tokens[0]?.symbol ?? 'USDC')
+  const sameChain = chain === DEST_CHAIN
+  const receiverAddress = sameChain ? address : (pm?.receiverAddress ?? null)
+
+  useEffect(() => {
+    if (!address || !isAvailable) return
+    if (sameChain) {
+      lastKey.current = ''
+      reset()
+      return
+    }
+    const key = `${chain}:${activeToken}`
+    if (lastKey.current === key) return
+    lastKey.current = key
+    fund(
+      { chain: DEST_CHAIN, currency: DEST_USDC, address },
+      {
+        type: 'cex',
+        cex: 'binance',
+        source: { chain, currency: addressFor(chain, activeToken), amount: NOMINAL_UNITS },
+      }
+    ).catch(() => {})
+  }, [address, chain, activeToken, isAvailable, sameChain, fund, reset])
+
+  useEffect(() => {
+    triggerResize()
+  }, [receiverAddress, loading, triggerResize])
+
+  const openPay = (exchange: string) => {
+    if (!address) return
+    const w = window.open('about:blank', '_blank', 'noopener,noreferrer')
+    void payLink({ exchange, address, asset: activeToken, chain: DEST_CHAIN, amount: '10' })
+      .then((url) => {
+        if (w) w.location.href = url
+      })
+      .catch(() => w?.close())
+  }
+
+  return (
+    <PageContent onBack={routes.DEPOSIT}>
+      <ModalHeading>Transfer from Exchange</ModalHeading>
+
+      <div style={twoCol}>
+        <label style={field}>
+          Network
+          <div style={selectWrap}>
+            <img src={chainLogo(chain)} alt="" style={logoImg} onError={hideBrokenLogo} />
+            <select style={bareSelect} value={chain} onChange={(e) => setChain(e.target.value)}>
+              {CEX_CHAINS.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </label>
+        <label style={field}>
+          Token
+          <div style={selectWrap}>
+            <img src={tokenLogo(chain, activeToken)} alt="" style={logoImg} onError={hideBrokenLogo} />
+            <select style={bareSelect} value={activeToken} onChange={(e) => setToken(e.target.value)}>
+              {tokens.map((t) => (
+                <option key={t.symbol} value={t.symbol}>
+                  {t.symbol}
+                </option>
+              ))}
+            </select>
+          </div>
+        </label>
+      </div>
+
+      {!isAvailable && <ModalBody>Set uiConfig.fundingBaseUrl to enable transfers.</ModalBody>}
+      {loading && !sameChain && !pm && <ModalBody style={{ marginTop: 12 }}>Fetching deposit address…</ModalBody>}
+
+      {receiverAddress && (
+        <>
+          <QRWrapper>
+            <CustomQRCode
+              value={receiverAddress}
+              image={<AssetChainLogo assetLogo={tokenLogo(chain, activeToken)} chainLogo={chainLogo(chain)} />}
+              imageBackground="#fff"
+            />
+          </QRWrapper>
+          <div style={rowCenter}>
+            <code style={codeStyle}>{receiverAddress}</code>
+            <CopyIconButton value={receiverAddress} />
+          </div>
+          {!sameChain && pm && <DepositDetails pm={pm} token={activeToken} />}
+          <div style={deeplinkRow}>
+            {PAY_EXCHANGES.map((ex) => (
+              <button key={ex} type="button" style={deeplinkBtn} onClick={() => openPay(ex)}>
+                Open on {titleCase(ex)} ↗
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+      {error && <ModalBody style={{ color: '#dc2626', marginTop: 12 }}>{error.message}</ModalBody>}
+    </PageContent>
+  )
+}
+
+export default DepositCex

--- a/packages/openfort-react/src/components/Pages/DepositCrypto/index.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositCrypto/index.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import type { SyntheticEvent } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { useEthereumEmbeddedWallet } from '../../../ethereum/hooks/useEthereumEmbeddedWallet'
+import { useFunding } from '../../../hooks/openfort/useFunding'
+import { CopyIconButton } from '../../Common/CopyToClipboard/CopyIconButton'
+import CustomQRCode from '../../Common/CustomQRCode'
+import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
+import { routes } from '../../Openfort/types'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+import { PageContent } from '../../PageContent'
+import { AssetChainLogo } from '../Deposit/AssetChainLogo'
+import { DepositDetails } from '../Deposit/Details'
+import {
+  bareSelect,
+  codeStyle,
+  deeplinkBtn,
+  deeplinkRow,
+  field,
+  logoImg,
+  rowCenter,
+  selectWrap,
+  twoCol,
+  walletListBtn,
+} from '../Deposit/formStyles'
+import {
+  addressFor,
+  chainLogo,
+  DEST_CHAIN,
+  DEST_USDC,
+  isSolana,
+  NOMINAL_UNITS,
+  SOURCE_CHAINS,
+  tokenLogo,
+  tokensFor,
+} from '../Deposit/sources'
+import { QRWrapper } from '../Deposit/styles'
+
+const hideBrokenLogo = (e: SyntheticEvent<HTMLImageElement>) => {
+  e.currentTarget.style.display = 'none'
+}
+
+/**
+ * Transfer crypto — choose a source chain + token; the deposit address + QR
+ * appear automatically. "Transfer crypto from wallet" opens a one-column list of
+ * wallet open-dApp links. Same-chain is a plain transfer to the wallet.
+ */
+const DepositCrypto = () => {
+  const wallet = useEthereumEmbeddedWallet()
+  const { triggerResize } = useOpenfort()
+  const { session, error, loading, isAvailable, fund, reset } = useFunding()
+  const address = wallet.status === 'connected' ? wallet.address : undefined
+  const firstChain = SOURCE_CHAINS[0]?.id ?? DEST_CHAIN
+  const [chain, setChain] = useState(firstChain)
+  const [token, setToken] = useState(tokensFor(firstChain)[0]?.symbol ?? 'USDC')
+  const [walletsOpen, setWalletsOpen] = useState(false)
+  const pm = session?.paymentMethod ?? null
+  const lastKey = useRef('')
+
+  const tokens = tokensFor(chain)
+  const activeToken = tokens.some((t) => t.symbol === token) ? token : (tokens[0]?.symbol ?? 'USDC')
+  const sameChain = chain === DEST_CHAIN
+  const receiverAddress = sameChain ? address : (pm?.receiverAddress ?? null)
+
+  useEffect(() => {
+    if (!address || !isAvailable) return
+    if (sameChain) {
+      lastKey.current = ''
+      reset()
+      return
+    }
+    const key = `${chain}:${activeToken}`
+    if (lastKey.current === key) return
+    lastKey.current = key
+    fund(
+      { chain: DEST_CHAIN, currency: DEST_USDC, address },
+      {
+        type: isSolana(chain) ? 'solana' : 'evm',
+        source: { chain, currency: addressFor(chain, activeToken), amount: NOMINAL_UNITS },
+      }
+    ).catch(() => {})
+  }, [address, chain, activeToken, isAvailable, sameChain, fund, reset])
+
+  useEffect(() => {
+    triggerResize()
+  }, [receiverAddress, loading, walletsOpen, triggerResize])
+
+  // Sub-page: one-column wallet list.
+  if (walletsOpen) {
+    return (
+      <PageContent onBack={() => setWalletsOpen(false)}>
+        <ModalHeading>Transfer crypto from wallet</ModalHeading>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 14 }}>
+          {(pm?.deeplinks ?? []).map((d) => (
+            <a key={d.app} href={d.url} target="_blank" rel="noreferrer" style={walletListBtn}>
+              {d.label} ↗
+            </a>
+          ))}
+        </div>
+      </PageContent>
+    )
+  }
+
+  return (
+    <PageContent onBack={routes.DEPOSIT}>
+      <ModalHeading>Transfer crypto</ModalHeading>
+
+      <div style={twoCol}>
+        <label style={field}>
+          Supported chain
+          <div style={selectWrap}>
+            <img src={chainLogo(chain)} alt="" style={logoImg} onError={hideBrokenLogo} />
+            <select style={bareSelect} value={chain} onChange={(e) => setChain(e.target.value)}>
+              {SOURCE_CHAINS.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </label>
+        <label style={field}>
+          Supported token
+          <div style={selectWrap}>
+            <img src={tokenLogo(chain, activeToken)} alt="" style={logoImg} onError={hideBrokenLogo} />
+            <select style={bareSelect} value={activeToken} onChange={(e) => setToken(e.target.value)}>
+              {tokens.map((t) => (
+                <option key={t.symbol} value={t.symbol}>
+                  {t.symbol}
+                </option>
+              ))}
+            </select>
+          </div>
+        </label>
+      </div>
+
+      {!isAvailable && <ModalBody>Set uiConfig.fundingBaseUrl to enable transfers.</ModalBody>}
+      {loading && !sameChain && !pm && <ModalBody style={{ marginTop: 12 }}>Fetching deposit address…</ModalBody>}
+
+      {receiverAddress && (
+        <>
+          <QRWrapper>
+            <CustomQRCode
+              value={receiverAddress}
+              image={<AssetChainLogo assetLogo={tokenLogo(chain, activeToken)} chainLogo={chainLogo(chain)} />}
+              imageBackground="#fff"
+            />
+          </QRWrapper>
+          <div style={rowCenter}>
+            <code style={codeStyle}>{receiverAddress}</code>
+            <CopyIconButton value={receiverAddress} />
+          </div>
+          {!sameChain && pm && <DepositDetails pm={pm} token={activeToken} />}
+          {!sameChain && pm && pm.deeplinks.length > 0 && (
+            <div style={deeplinkRow}>
+              <button type="button" style={deeplinkBtn} onClick={() => setWalletsOpen(true)}>
+                Transfer crypto from wallet ›
+              </button>
+            </div>
+          )}
+        </>
+      )}
+      {error && <ModalBody style={{ color: '#dc2626', marginTop: 12 }}>{error.message}</ModalBody>}
+    </PageContent>
+  )
+}
+
+export default DepositCrypto

--- a/packages/openfort-react/src/components/Pages/DepositCrypto/index.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositCrypto/index.tsx
@@ -13,17 +13,18 @@ import { PageContent } from '../../PageContent'
 import { AssetChainLogo } from '../Deposit/AssetChainLogo'
 import { DepositDetails } from '../Deposit/Details'
 import {
+  addressBox,
   bareSelect,
   codeStyle,
   deeplinkBtn,
   deeplinkRow,
   field,
   logoImg,
-  rowCenter,
   selectWrap,
   twoCol,
   walletListBtn,
 } from '../Deposit/formStyles'
+import { OrDivider } from '../Deposit/OrDivider'
 import {
   addressFor,
   chainLogo,
@@ -147,17 +148,20 @@ const DepositCrypto = () => {
               imageBackground="#fff"
             />
           </QRWrapper>
-          <div style={rowCenter}>
+          <div style={addressBox}>
             <code style={codeStyle}>{receiverAddress}</code>
             <CopyIconButton value={receiverAddress} />
           </div>
-          {!sameChain && pm && <DepositDetails pm={pm} token={activeToken} />}
+          {!sameChain && pm && <DepositDetails pm={pm} />}
           {!sameChain && pm && pm.deeplinks.length > 0 && (
-            <div style={deeplinkRow}>
-              <button type="button" style={deeplinkBtn} onClick={() => setWalletsOpen(true)}>
-                Transfer crypto from wallet ›
-              </button>
-            </div>
+            <>
+              <OrDivider />
+              <div style={deeplinkRow}>
+                <button type="button" style={deeplinkBtn} onClick={() => setWalletsOpen(true)}>
+                  Transfer crypto from wallet ›
+                </button>
+              </div>
+            </>
           )}
         </>
       )}

--- a/packages/openfort-react/src/components/Pages/NoAssetsAvailable/index.tsx
+++ b/packages/openfort-react/src/components/Pages/NoAssetsAvailable/index.tsx
@@ -1,8 +1,4 @@
-import { ChainTypeEnum } from '@openfort/openfort-js'
-import { BuyIcon, DollarIcon, ReceiveIcon } from '../../../assets/icons'
-import { useEthereumEmbeddedWallet } from '../../../ethereum/hooks/useEthereumEmbeddedWallet'
-import { useOpenfortCore } from '../../../openfort/useOpenfort'
-import { useSolanaEmbeddedWallet } from '../../../solana/hooks/useSolanaEmbeddedWallet'
+import { BuyIcon, DollarIcon } from '../../../assets/icons'
 import Button from '../../Common/Button'
 import { ModalBody, ModalContent, ModalH1 } from '../../Common/Modal/styles'
 import { FloatingGraphic } from '../../FloatingGraphic'
@@ -12,20 +8,7 @@ import { PageContent } from '../../PageContent'
 import { ButtonsContainer } from './styles'
 
 export const NoAssetsAvailable = () => {
-  const { setRoute, chains } = useOpenfort()
-  const { chainType } = useOpenfortCore()
-
-  // Use chain-specific hooks
-  const ethereumWallet = useEthereumEmbeddedWallet()
-  const solanaWallet = useSolanaEmbeddedWallet()
-  const wallet = chainType === ChainTypeEnum.EVM ? ethereumWallet : solanaWallet
-
-  const chainId =
-    wallet.status === 'connected' && chainType === ChainTypeEnum.EVM
-      ? (wallet as typeof ethereumWallet).chainId
-      : undefined
-  const chain = chains.find((c) => c.id === chainId)
-  const showBuyOption = chain && !chain.testnet
+  const { setRoute } = useOpenfort()
 
   return (
     <PageContent>
@@ -56,22 +39,12 @@ export const NoAssetsAvailable = () => {
           <ButtonsContainer>
             <Button
               onClick={() => {
-                setRoute(routes.RECEIVE)
+                setRoute(routes.DEPOSIT)
               }}
-              icon={<ReceiveIcon />}
+              icon={<DollarIcon />}
             >
-              Get assets
+              Add funds
             </Button>
-            {showBuyOption && (
-              <Button
-                onClick={() => {
-                  setRoute(routes.BUY)
-                }}
-                icon={<BuyIcon />}
-              >
-                Buy assets
-              </Button>
-            )}
           </ButtonsContainer>
         </ModalBody>
       </ModalContent>

--- a/packages/openfort-react/src/hooks/openfort/fundingClient.ts
+++ b/packages/openfort-react/src/hooks/openfort/fundingClient.ts
@@ -1,0 +1,74 @@
+import type { FundingSession, FundingTarget, PayLinkParams, PaymentMethodInput } from './useFunding'
+
+/**
+ * The funding client surface, mirroring the planned `openfort.funding.*`
+ * namespace in `@openfort/openfort-js`:
+ *
+ *   openfort.funding.sessions.create({ target })
+ *   openfort.funding.sessions.setPaymentMethod(id, { clientSecret, paymentMethod })
+ *   openfort.funding.sessions.get(id, { clientSecret? })
+ *   openfort.funding.payLink(params)
+ *
+ * `useFunding` depends only on this interface. Today it's backed by the
+ * fetch adapter below (the standalone funding service); once the SDK ships the
+ * namespace, the adapter is swapped for `coreClient.funding` with no hook change.
+ */
+export type FundingClient = {
+  sessions: {
+    create(params: { target: FundingTarget }): Promise<FundingSession>
+    setPaymentMethod(
+      id: string,
+      params: { clientSecret: string; paymentMethod: PaymentMethodInput }
+    ): Promise<FundingSession>
+    get(id: string, params?: { clientSecret?: string }): Promise<FundingSession>
+  }
+  payLink(params: PayLinkParams): Promise<string>
+}
+
+async function readJson<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string }
+    throw new Error(body.error ?? `Funding request failed (${res.status})`)
+  }
+  return res.json() as Promise<T>
+}
+
+/**
+ * Fetch-backed funding client against the standalone funding service at
+ * `baseUrl`. Temporary: replaced by the SDK's `funding` namespace at cutover.
+ */
+export function createFetchFundingClient(baseUrl: string): FundingClient {
+  return {
+    sessions: {
+      async create({ target }) {
+        const res = await fetch(`${baseUrl}/v1/funding/sessions`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ target }),
+        })
+        return readJson<FundingSession>(res)
+      },
+      async setPaymentMethod(id, { clientSecret, paymentMethod }) {
+        const res = await fetch(`${baseUrl}/v1/funding/sessions/${id}/paymentMethods`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ clientSecret, paymentMethod }),
+        })
+        return readJson<FundingSession>(res)
+      },
+      async get(id, params) {
+        const query = params?.clientSecret ? `?clientSecret=${encodeURIComponent(params.clientSecret)}` : ''
+        return readJson<FundingSession>(await fetch(`${baseUrl}/v1/funding/sessions/${id}${query}`))
+      },
+    },
+    async payLink(params) {
+      const res = await fetch(`${baseUrl}/v1/funding/pay-link`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(params),
+      })
+      const data = await readJson<{ url: string }>(res)
+      return data.url
+    },
+  }
+}

--- a/packages/openfort-react/src/hooks/openfort/useFunding.ts
+++ b/packages/openfort-react/src/hooks/openfort/useFunding.ts
@@ -1,0 +1,259 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+import { useOpenfort } from '../../components/Openfort/useOpenfort'
+
+/**
+ * Funding session client — adapted from the openfort-funding prototype.
+ *
+ * A session is one deposit attempt against a destination. The client creates a
+ * session, sets one payment method (a source the user commits to sending from),
+ * then polls until the session reaches a terminal state. The response carries
+ * everything the UI (or an agent) needs: a receiver address, a scannable URI,
+ * prefilled wallet deeplinks, and CEX guidance.
+ *
+ * The network layer is stubbed: it compiles and drives the UI state machine,
+ * but does not talk to a live backend yet.
+ *
+ * TODO(openfort-funding-backend): replace the stubbed `createSession`,
+ * `setPaymentMethod`, and `getSession` calls with real `fetch` requests against
+ * `${fundingBaseUrl}/v1/funding/sessions...`. The prototype flow is:
+ *   POST /v1/funding/sessions               { target }              -> FundingSession
+ *   POST /v1/funding/sessions/:id/paymentMethods { clientSecret, paymentMethod } -> FundingSession
+ *   GET  /v1/funding/sessions/:id?clientSecret=...                  -> FundingSession (poll)
+ */
+
+/** Where funds should land. CAIP-2 chain + token contract (or native) + wallet. */
+export type FundingTarget = {
+  /** CAIP-2 chain id, e.g. "eip155:8453" for Base. */
+  chain: string
+  /** Token contract address, or the zero address for the chain's native asset. */
+  currency: string
+  /** Destination wallet that receives the bridged funds. */
+  address: string
+}
+
+/** The route the user commits to sending from. */
+export type FundingSource = {
+  /** CAIP-2 chain id the user sends from, e.g. "eip155:137". */
+  chain: string
+  /** Token contract the user sends, or the zero address for native. */
+  currency: string
+  /** Amount in the source token's smallest unit (wei, lamports, base units). */
+  amount: string
+}
+
+/** Session lifecycle, mirroring the prototype's vocabulary. */
+export type SessionStatus =
+  | 'requires_payment_method'
+  | 'waiting_payment'
+  | 'processing'
+  | 'succeeded'
+  | 'bounced'
+  | 'expired'
+
+export type FundingFee = {
+  kind: 'gas' | 'relayerGas' | 'relayerService' | 'app'
+  amount: string
+  currency: string
+}
+
+/**
+ * Payment-method-per-source input. `evm` and `solana` are self-custody wallet
+ * sends (they get wallet deeplinks); `cex` is an exchange withdrawal (no
+ * deeplink — exchanges can't be deeplinked into).
+ */
+export type PaymentMethodInput =
+  | { type: 'evm'; source: FundingSource }
+  | { type: 'solana'; source: FundingSource }
+  | { type: 'cex'; cex: string; source: FundingSource }
+
+export type PaymentMethodType = PaymentMethodInput['type']
+
+/** A prefilled deeplink into a source wallet app (e.g. Trust Wallet). */
+export type WalletDeeplink = { app: string; label: string; url: string }
+
+/** Per-exchange guidance for the guided CEX flow. */
+export type CexGuidance = {
+  exchange: string
+  network: string
+  minWithdrawal: string | null
+  requiresMemo: boolean
+}
+
+/** A resolved payment method — what the UI renders and the agent reads. */
+export type PaymentMethod = {
+  type: PaymentMethodType
+  source: FundingSource
+  /** Address the user (or their CEX/wallet) sends to. */
+  receiverAddress: string
+  /** Provider-side id used to track settlement. */
+  providerRequestId: string
+  /** BIP-21 / EIP-681 URI for QR. Scanner support for amount/token varies. */
+  addressUri: string
+  /** Prefilled deeplinks for source wallet apps, when available. */
+  deeplinks: WalletDeeplink[]
+  /** Guidance for the "cex" type; null otherwise. */
+  cex: CexGuidance | null
+  fees: FundingFee[]
+  /** Minimum to send for this route (source base units), or null. */
+  minAmount: string | null
+}
+
+/** A single deposit attempt. */
+export type FundingSession = {
+  id: string
+  clientSecret: string
+  target: FundingTarget
+  status: SessionStatus
+  amountUnits: string | null
+  metadata: Record<string, string> | null
+  externalId: string | null
+  createdAt: number
+  expiresAt: number
+  paymentMethod: PaymentMethod | null
+}
+
+const TERMINAL: SessionStatus[] = ['succeeded', 'bounced', 'expired']
+const POLL_MS = 4000
+
+export type UseFunding = {
+  session: FundingSession | null
+  status: SessionStatus | 'idle'
+  error: Error | null
+  /** True while a session is being created and its deposit address fetched. */
+  loading: boolean
+  /** True when the funding backend is configured (uiConfig.fundingBaseUrl set). */
+  isAvailable: boolean
+  /** Create a session, set a payment method, and poll until terminal. */
+  fund: (target: FundingTarget, paymentMethod: PaymentMethodInput) => Promise<FundingSession>
+  /** Resolve a prefilled exchange pay URL (Coinbase/Binance) from the backend. */
+  payLink: (params: PayLinkParams) => Promise<string>
+  /** Reset to the idle state (e.g. when leaving the Deposit flow). */
+  reset: () => void
+}
+
+/** Parameters for an exchange pay-link request. */
+export type PayLinkParams = {
+  exchange: string
+  address: string
+  asset: string
+  chain: string
+  amount?: string
+}
+
+// --- Network layer ---------------------------------------------------------
+// The three calls against the openfort-funding backend. The hook's state
+// machine below drives create → set payment method → poll until terminal.
+
+async function readJson<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string }
+    throw new Error(body.error ?? `Funding request failed (${res.status})`)
+  }
+  return res.json() as Promise<T>
+}
+
+async function createSession(baseUrl: string, target: FundingTarget): Promise<FundingSession> {
+  const res = await fetch(`${baseUrl}/v1/funding/sessions`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ target }),
+  })
+  return readJson<FundingSession>(res)
+}
+
+async function setPaymentMethod(
+  baseUrl: string,
+  session: FundingSession,
+  paymentMethod: PaymentMethodInput
+): Promise<FundingSession> {
+  const res = await fetch(`${baseUrl}/v1/funding/sessions/${session.id}/paymentMethods`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ clientSecret: session.clientSecret, paymentMethod }),
+  })
+  return readJson<FundingSession>(res)
+}
+
+async function getSession(baseUrl: string, session: FundingSession): Promise<FundingSession> {
+  const url = `${baseUrl}/v1/funding/sessions/${session.id}?clientSecret=${encodeURIComponent(session.clientSecret)}`
+  return readJson<FundingSession>(await fetch(url))
+}
+
+/**
+ * React surface over the funding session API.
+ *
+ * @returns Session state plus `fund` (run the deposit flow) and `reset`.
+ */
+export function useFunding(): UseFunding {
+  const { uiConfig } = useOpenfort()
+  const baseUrl = uiConfig.fundingBaseUrl ?? ''
+  const isAvailable = baseUrl.length > 0
+
+  const [session, setSession] = useState<FundingSession | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+  const [loading, setLoading] = useState(false)
+  // Generation guard: only the latest fund()/reset() updates state, so
+  // re-selecting a source mid-poll can't be clobbered by a stale request.
+  const generation = useRef(0)
+
+  const reset = useCallback(() => {
+    generation.current += 1
+    setSession(null)
+    setError(null)
+    setLoading(false)
+  }, [])
+
+  const fund = useCallback(
+    async (target: FundingTarget, paymentMethod: PaymentMethodInput): Promise<FundingSession> => {
+      generation.current += 1
+      const gen = generation.current
+      const isCurrent = () => generation.current === gen
+      setError(null)
+      setLoading(true)
+      try {
+        if (!isAvailable) {
+          throw new Error('Funding backend not configured (set uiConfig.fundingBaseUrl)')
+        }
+        const created = await createSession(baseUrl, target)
+        let current = await setPaymentMethod(baseUrl, created, paymentMethod)
+        if (!isCurrent()) return current
+        setSession(current)
+        setLoading(false)
+
+        while (!TERMINAL.includes(current.status)) {
+          await new Promise((resolve) => setTimeout(resolve, POLL_MS))
+          if (!isCurrent()) return current
+          current = await getSession(baseUrl, current)
+          if (!isCurrent()) return current
+          setSession(current)
+        }
+        return current
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e))
+        if (isCurrent()) {
+          setError(err)
+          setLoading(false)
+        }
+        throw err
+      }
+    },
+    [baseUrl, isAvailable]
+  )
+
+  const payLink = useCallback(
+    async (params: PayLinkParams): Promise<string> => {
+      const res = await fetch(`${baseUrl}/v1/funding/pay-link`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(params),
+      })
+      const data = (await res.json()) as { url: string }
+      return data.url
+    },
+    [baseUrl]
+  )
+
+  return { session, status: session?.status ?? 'idle', error, loading, isAvailable, fund, payLink, reset }
+}

--- a/packages/openfort-react/src/hooks/openfort/useFunding.ts
+++ b/packages/openfort-react/src/hooks/openfort/useFunding.ts
@@ -1,7 +1,8 @@
 'use client'
 
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useOpenfort } from '../../components/Openfort/useOpenfort'
+import { createFetchFundingClient, type FundingClient } from './fundingClient'
 
 /**
  * Funding session client — adapted from the openfort-funding prototype.
@@ -12,15 +13,10 @@ import { useOpenfort } from '../../components/Openfort/useOpenfort'
  * everything the UI (or an agent) needs: a receiver address, a scannable URI,
  * prefilled wallet deeplinks, and CEX guidance.
  *
- * The network layer is stubbed: it compiles and drives the UI state machine,
- * but does not talk to a live backend yet.
- *
- * TODO(openfort-funding-backend): replace the stubbed `createSession`,
- * `setPaymentMethod`, and `getSession` calls with real `fetch` requests against
- * `${fundingBaseUrl}/v1/funding/sessions...`. The prototype flow is:
- *   POST /v1/funding/sessions               { target }              -> FundingSession
- *   POST /v1/funding/sessions/:id/paymentMethods { clientSecret, paymentMethod } -> FundingSession
- *   GET  /v1/funding/sessions/:id?clientSecret=...                  -> FundingSession (poll)
+ * The hook depends on a {@link FundingClient}, not on `fetch` directly. Today the
+ * default client is the fetch adapter over `uiConfig.fundingBaseUrl`; once
+ * `@openfort/openfort-js` ships the `funding` namespace, the resolution below
+ * swaps to `coreClient.funding` with no change to this hook.
  */
 
 /** Where funds should land. CAIP-2 chain + token contract (or native) + wallet. */
@@ -123,7 +119,7 @@ export type UseFunding = {
   error: Error | null
   /** True while a session is being created and its deposit address fetched. */
   loading: boolean
-  /** True when the funding backend is configured (uiConfig.fundingBaseUrl set). */
+  /** True when a funding client is resolved (injected, or uiConfig.fundingBaseUrl set). */
   isAvailable: boolean
   /** Create a session, set a payment method, and poll until terminal. */
   fund: (target: FundingTarget, paymentMethod: PaymentMethodInput) => Promise<FundingSession>
@@ -142,43 +138,11 @@ export type PayLinkParams = {
   amount?: string
 }
 
-// --- Network layer ---------------------------------------------------------
-// The three calls against the openfort-funding backend. The hook's state
-// machine below drives create → set payment method → poll until terminal.
-
-async function readJson<T>(res: Response): Promise<T> {
-  if (!res.ok) {
-    const body = (await res.json().catch(() => ({}))) as { error?: string }
-    throw new Error(body.error ?? `Funding request failed (${res.status})`)
-  }
-  return res.json() as Promise<T>
-}
-
-async function createSession(baseUrl: string, target: FundingTarget): Promise<FundingSession> {
-  const res = await fetch(`${baseUrl}/v1/funding/sessions`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ target }),
-  })
-  return readJson<FundingSession>(res)
-}
-
-async function setPaymentMethod(
-  baseUrl: string,
-  session: FundingSession,
-  paymentMethod: PaymentMethodInput
-): Promise<FundingSession> {
-  const res = await fetch(`${baseUrl}/v1/funding/sessions/${session.id}/paymentMethods`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ clientSecret: session.clientSecret, paymentMethod }),
-  })
-  return readJson<FundingSession>(res)
-}
-
-async function getSession(baseUrl: string, session: FundingSession): Promise<FundingSession> {
-  const url = `${baseUrl}/v1/funding/sessions/${session.id}?clientSecret=${encodeURIComponent(session.clientSecret)}`
-  return readJson<FundingSession>(await fetch(url))
+/** Options for {@link useFunding}. */
+export type UseFundingOptions = {
+  /** Inject a funding client (tests, or a custom backend). Defaults to the
+   * fetch adapter over `uiConfig.fundingBaseUrl`. */
+  client?: FundingClient
 }
 
 /**
@@ -186,10 +150,17 @@ async function getSession(baseUrl: string, session: FundingSession): Promise<Fun
  *
  * @returns Session state plus `fund` (run the deposit flow) and `reset`.
  */
-export function useFunding(): UseFunding {
+export function useFunding(options?: UseFundingOptions): UseFunding {
   const { uiConfig } = useOpenfort()
   const baseUrl = uiConfig.fundingBaseUrl ?? ''
-  const isAvailable = baseUrl.length > 0
+  const injected = options?.client
+  // Resolve the client: an injected one wins; otherwise the fetch adapter when a
+  // base URL is configured. When openfort-js ships `funding`, prefer that here.
+  const client = useMemo<FundingClient | null>(
+    () => injected ?? (baseUrl ? createFetchFundingClient(baseUrl) : null),
+    [injected, baseUrl]
+  )
+  const isAvailable = client != null
 
   const [session, setSession] = useState<FundingSession | null>(null)
   const [error, setError] = useState<Error | null>(null)
@@ -213,11 +184,14 @@ export function useFunding(): UseFunding {
       setError(null)
       setLoading(true)
       try {
-        if (!isAvailable) {
-          throw new Error('Funding backend not configured (set uiConfig.fundingBaseUrl)')
+        if (!client) {
+          throw new Error('Funding is not configured (set uiConfig.fundingBaseUrl)')
         }
-        const created = await createSession(baseUrl, target)
-        let current = await setPaymentMethod(baseUrl, created, paymentMethod)
+        const created = await client.sessions.create({ target })
+        let current = await client.sessions.setPaymentMethod(created.id, {
+          clientSecret: created.clientSecret,
+          paymentMethod,
+        })
         if (!isCurrent()) return current
         setSession(current)
         setLoading(false)
@@ -225,7 +199,7 @@ export function useFunding(): UseFunding {
         while (!TERMINAL.includes(current.status)) {
           await new Promise((resolve) => setTimeout(resolve, POLL_MS))
           if (!isCurrent()) return current
-          current = await getSession(baseUrl, current)
+          current = await client.sessions.get(current.id, { clientSecret: current.clientSecret })
           if (!isCurrent()) return current
           setSession(current)
         }
@@ -239,20 +213,15 @@ export function useFunding(): UseFunding {
         throw err
       }
     },
-    [baseUrl, isAvailable]
+    [client]
   )
 
   const payLink = useCallback(
     async (params: PayLinkParams): Promise<string> => {
-      const res = await fetch(`${baseUrl}/v1/funding/pay-link`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(params),
-      })
-      const data = (await res.json()) as { url: string }
-      return data.url
+      if (!client) throw new Error('Funding is not configured (set uiConfig.fundingBaseUrl)')
+      return client.payLink(params)
     },
-    [baseUrl]
+    [client]
   )
 
   return { session, status: session?.status ?? 'idle', error, loading, isAvailable, fund, payLink, reset }

--- a/packages/openfort-react/src/index.ts
+++ b/packages/openfort-react/src/index.ts
@@ -82,6 +82,7 @@ export type { StoreCredentialsResult } from './hooks/openfort/auth/useOAuth'
 export { useOAuth } from './hooks/openfort/auth/useOAuth'
 export { usePhoneOtpAuth } from './hooks/openfort/auth/usePhoneOtpAuth'
 export { useSignOut } from './hooks/openfort/auth/useSignOut'
+export type { FundingClient } from './hooks/openfort/fundingClient'
 export {
   type SignAuthorizationParameters,
   type SignAuthorizationReturnType,
@@ -93,6 +94,7 @@ export type {
   PaymentMethod,
   PaymentMethodInput,
   UseFunding,
+  UseFundingOptions,
 } from './hooks/openfort/useFunding'
 export { useFunding } from './hooks/openfort/useFunding'
 export { useGrantPermissions } from './hooks/openfort/useGrantPermissions'

--- a/packages/openfort-react/src/index.ts
+++ b/packages/openfort-react/src/index.ts
@@ -87,6 +87,14 @@ export {
   type SignAuthorizationReturnType,
   use7702Authorization,
 } from './hooks/openfort/use7702Authorization'
+export type {
+  FundingSession,
+  FundingTarget,
+  PaymentMethod,
+  PaymentMethodInput,
+  UseFunding,
+} from './hooks/openfort/useFunding'
+export { useFunding } from './hooks/openfort/useFunding'
 export { useGrantPermissions } from './hooks/openfort/useGrantPermissions'
 export { useRevokePermissions } from './hooks/openfort/useRevokePermissions'
 export { useUI } from './hooks/openfort/useUI'


### PR DESCRIPTION
Adds a wallet-funding **Deposit** module to the modal: one entry point that routes to cross-chain crypto, exchange withdrawal, and the existing fiat Card flow. Built on a session-based funding service (Relay deposit addresses + Coinbase/Binance pay-links), behind a client seam so it cuts over to the SDK's `openfort.funding.*` namespace with no rewrite.

## What's included
- **Deposit hub** — method selector (Card / Transfer crypto / Transfer from Exchange), device-aware ordering, single entry point. Replaces the separate Buy/Receive buttons; the empty-wallet state routes here too.
- **Transfer crypto** — cross-chain Relay deposit address with a QR (asset logo + chain badge), auto-fetched on chain/token select, a shadow-boxed address, a collapsible Details panel (min / relay fee / time / max), and a one-column "Transfer crypto from wallet" sub-page of wallet open-dApp links. Same-chain is a plain transfer (no Relay).
- **Transfer from Exchange** — per-network deposit address plus "Open Coinbase" / "Open Binance" prefilled pay-link buttons.
- **`useFunding` behind a `FundingClient` seam** — the hook depends on an interface mirroring the planned `openfort.funding.*` SDK namespace (`sessions.create / setPaymentMethod / get` + `payLink`). The fetch adapter over `uiConfig.fundingBaseUrl` is the default and preserves current behavior; cutover to `coreClient.funding` is a one-line swap.
- **Tests** — `useFunding` unit tests against a mocked client (create+set, terminal-without-poll, error capture, stale-call abort, pay link, reset). Plus a jsdom `localStorage`/`sessionStorage` polyfill in the shared test setup (fixes a pre-existing `phase0` failure). Full suite green.

## Not included (follow-up, blocked on the API)
The production funding service (`funding_session` resource + routes + secrets) lands in the core Openfort API, and `@openfort/openfort-js` gains the `funding` namespace. Until then the hook runs against the standalone funding service via `uiConfig.fundingBaseUrl`. Cutover is a one-line swap behind the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)