### PR TITLE
fix(ui): restore gotoAndOpen fix

### DIFF
--- a/packages/openfort-react/src/__tests__/hooks/useUI.gotoAndOpen.test.tsx
+++ b/packages/openfort-react/src/__tests__/hooks/useUI.gotoAndOpen.test.tsx
@@ -1,0 +1,93 @@
+import { ChainTypeEnum, EmbeddedState } from '@openfort/openfort-js'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { routes } from '../../components/Openfort/types'
+
+/**
+ * Regression guard for gotoAndOpen (openWallets infinite-loading bug).
+ *
+ * OpenfortProvider.setOpen(true) resets the route to LOADING to clear stale
+ * state. gotoAndOpen must therefore call setOpen BEFORE setRoute, and must
+ * match route specs by route name (openWallets passes a fresh object literal,
+ * so reference equality never matches). The mock below mirrors the provider's
+ * reset-on-open semantics so the wrong call order fails the test.
+ */
+
+const state: { route: { route: string }; open: boolean } = { route: { route: routes.LOADING }, open: false }
+
+const setRoute = vi.fn((r: string | { route: string }) => {
+  state.route = typeof r === 'string' ? { route: r } : r
+})
+const setOpen = vi.fn((value: boolean) => {
+  if (value) state.route = { route: routes.LOADING }
+  state.open = value
+})
+const setConnector = vi.fn()
+
+vi.mock('../../components/Openfort/useOpenfort', () => ({
+  useOpenfort: () => ({
+    open: state.open,
+    setOpen,
+    setRoute,
+    setConnector,
+    connector: { id: '' },
+    chainType: ChainTypeEnum.EVM,
+  }),
+}))
+vi.mock('../../openfort/useOpenfort', () => ({
+  useOpenfortCore: () => ({
+    isLoading: false,
+    user: null,
+    needsRecovery: false,
+    embeddedAccounts: undefined,
+    activeEmbeddedAddress: undefined,
+    embeddedState: EmbeddedState.UNAUTHENTICATED,
+  }),
+}))
+vi.mock('../../core/ConnectionStrategyContext', () => ({ useConnectionStrategy: () => null }))
+vi.mock('../../ethereum/OpenfortEthereumBridgeContext', () => ({ useEthereumBridge: () => null }))
+vi.mock('../../ethereum/hooks/useEthereumEmbeddedWallet', () => ({
+  useEthereumEmbeddedWallet: () => ({ status: 'disconnected' }),
+}))
+vi.mock('../../solana/hooks/useSolanaEmbeddedWallet', () => ({
+  useSolanaEmbeddedWallet: () => ({ status: 'disconnected' }),
+}))
+
+const { useUI } = await import('../../hooks/openfort/useUI')
+
+describe('useUI gotoAndOpen', () => {
+  beforeEach(() => {
+    state.route = { route: routes.LOADING }
+    state.open = false
+    vi.clearAllMocks()
+  })
+
+  it('openWallets lands on CONNECTORS, not clobbered back to LOADING', () => {
+    const { result } = renderHook(() => useUI())
+
+    act(() => result.current.openWallets())
+
+    expect(state.open).toBe(true)
+    expect(state.route).toMatchObject({ route: routes.CONNECTORS, connectType: 'linkIfUserConnectIfNoUser' })
+  })
+
+  it('opens the modal before setting the route', () => {
+    const { result } = renderHook(() => useUI())
+
+    act(() => result.current.openWallets())
+
+    const openOrder = setOpen.mock.invocationCallOrder[0]
+    const routeOrder = setRoute.mock.invocationCallOrder[0]
+    expect(openOrder).toBeLessThan(routeOrder)
+  })
+
+  it('falls back to PROVIDERS for routes not allowed while disconnected', () => {
+    const { result } = renderHook(() => useUI())
+
+    // CONNECTED is not in the disconnected allowlist
+    act(() => result.current.openProfile())
+
+    expect(state.open).toBe(true)
+    expect(state.route).toMatchObject({ route: routes.PROVIDERS })
+  })
+})

--- a/packages/openfort-react/src/__tests__/hooks/useUI.gotoAndOpen.test.tsx
+++ b/packages/openfort-react/src/__tests__/hooks/useUI.gotoAndOpen.test.tsx
@@ -71,16 +71,6 @@ describe('useUI gotoAndOpen', () => {
     expect(state.route).toMatchObject({ route: routes.CONNECTORS, connectType: 'linkIfUserConnectIfNoUser' })
   })
 
-  it('opens the modal before setting the route', () => {
-    const { result } = renderHook(() => useUI())
-
-    act(() => result.current.openWallets())
-
-    const openOrder = setOpen.mock.invocationCallOrder[0]
-    const routeOrder = setRoute.mock.invocationCallOrder[0]
-    expect(openOrder).toBeLessThan(routeOrder)
-  })
-
   it('falls back to PROVIDERS for routes not allowed while disconnected', () => {
     const { result } = renderHook(() => useUI())
 

--- a/packages/openfort-react/src/__tests__/pages/Loading.timeout.test.tsx
+++ b/packages/openfort-react/src/__tests__/pages/Loading.timeout.test.tsx
@@ -1,0 +1,85 @@
+import { ChainTypeEnum, EmbeddedState } from '@openfort/openfort-js'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { routes } from '../../components/Openfort/types'
+
+/**
+ * Watchdog test: the LOADING page must not spin forever. When no state
+ * transition routes away (e.g. modal opened while signed out and the SDK
+ * never settles), it falls back to a not-found page with a way back to
+ * the sign-in screen.
+ */
+
+const setRoute = vi.fn()
+
+vi.mock('../../components/Openfort/useOpenfort', () => ({
+  useOpenfort: () => ({
+    setRoute,
+    walletConfig: undefined,
+    uiConfig: {},
+    triggerResize: vi.fn(),
+    setOnBack: vi.fn(),
+    setPreviousRoute: vi.fn(),
+    setRouteHistory: vi.fn(),
+  }),
+}))
+vi.mock('../../openfort/useOpenfort', () => ({
+  useOpenfortCore: () => ({
+    user: null,
+    isLoading: false,
+    isLoadingAccounts: false,
+    needsRecovery: false,
+    embeddedState: EmbeddedState.UNAUTHENTICATED,
+    chainType: ChainTypeEnum.EVM,
+  }),
+}))
+vi.mock('../../ethereum/OpenfortEthereumBridgeContext', () => ({ useEthereumBridge: () => null }))
+vi.mock('../../ethereum/hooks/useEthereumEmbeddedWallet', () => ({
+  useEthereumEmbeddedWallet: () => ({ status: 'disconnected' }),
+}))
+vi.mock('../../solana/hooks/useSolanaEmbeddedWallet', () => ({
+  useSolanaEmbeddedWallet: () => ({ status: 'disconnected' }),
+}))
+vi.mock('../../hooks/openfort/auth/useSignOut', () => ({ useSignOut: () => ({ signOut: vi.fn() }) }))
+// FitText measures DOM sizes that jsdom cannot provide
+vi.mock('../../components/Common/FitText', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+const { default: Loading } = await import('../../components/Pages/Loading')
+
+describe('Loading page watchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setRoute.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows the spinner before the timeout elapses', () => {
+    render(<Loading />)
+
+    act(() => vi.advanceTimersByTime(5_000))
+
+    expect(screen.queryByText(/couldn't find what you're looking for/i)).toBeNull()
+  })
+
+  it('falls back to not-found after the timeout instead of spinning forever', () => {
+    render(<Loading />)
+
+    act(() => vi.advanceTimersByTime(10_000))
+
+    expect(screen.getByText(/couldn't find what you're looking for/i)).toBeTruthy()
+  })
+
+  it('"Back to sign in" routes to the providers (sign-in) page', () => {
+    render(<Loading />)
+
+    act(() => vi.advanceTimersByTime(10_000))
+    fireEvent.click(screen.getByText('Back to sign in'))
+
+    expect(setRoute).toHaveBeenCalledWith(routes.PROVIDERS)
+  })
+})

--- a/packages/openfort-react/src/__tests__/pages/Loading.timeout.test.tsx
+++ b/packages/openfort-react/src/__tests__/pages/Loading.timeout.test.tsx
@@ -63,7 +63,7 @@ describe('Loading page watchdog', () => {
 
     act(() => vi.advanceTimersByTime(5_000))
 
-    expect(screen.queryByText(/couldn't find what you're looking for/i)).toBeNull()
+    expect(screen.queryByText(/taking longer than expected/i)).toBeNull()
   })
 
   it('falls back to not-found after the timeout instead of spinning forever', () => {
@@ -71,7 +71,7 @@ describe('Loading page watchdog', () => {
 
     act(() => vi.advanceTimersByTime(10_000))
 
-    expect(screen.getByText(/couldn't find what you're looking for/i)).toBeTruthy()
+    expect(screen.getByText(/taking longer than expected/i)).toBeTruthy()
   })
 
   it('"Back to sign in" routes to the providers (sign-in) page', () => {

--- a/packages/openfort-react/src/__tests__/pages/WalletConnectNotConfigured.test.tsx
+++ b/packages/openfort-react/src/__tests__/pages/WalletConnectNotConfigured.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../../components/Openfort/useOpenfort', () => ({
   }),
 }))
 vi.mock('../../ethereum/OpenfortEthereumBridgeContext', () => ({ useEthereumBridge: () => bridgeValue }))
+vi.mock('../../openfort/useOpenfort', () => ({ useOpenfortCore: () => ({ user: null }) }))
 vi.mock('../../core/ConnectionStrategyContext', () => ({ useConnectionStrategy: () => null }))
 vi.mock('../../hooks/openfort/auth/useSignOut', () => ({ useSignOut: () => ({ signOut: vi.fn() }) }))
 // FitText measures DOM sizes that jsdom cannot provide
@@ -64,11 +65,22 @@ describe('WalletConnectNotConfigured page', () => {
     setRoute.mockClear()
   })
 
-  it('explains the missing WalletConnect project ID', () => {
+  it('shows end-user copy without developer config details', () => {
     render(<WalletConnectNotConfigured />)
 
-    expect(screen.getByText('WalletConnect is not configured')).toBeTruthy()
-    expect(screen.getByText(/project ID environment variable/i)).toBeTruthy()
+    expect(screen.getByText('Wallet connections unavailable')).toBeTruthy()
+    expect(screen.getByText(/another sign-in method/i)).toBeTruthy()
+    // env-var / projectId speak must not reach end users
+    expect(screen.queryByText(/environment variable|project ID/i)).toBeNull()
+  })
+
+  it('warns the developer in the console with the config hint', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    render(<WalletConnectNotConfigured />)
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('walletConnectProjectId'))
+    warnSpy.mockRestore()
   })
 
   it('"Back to sign in" routes to the providers (sign-in) page', () => {
@@ -86,6 +98,6 @@ describe('MobileConnectors without WalletConnect', () => {
 
     render(<MobileConnectors />)
 
-    expect(screen.getByText('WalletConnect is not configured')).toBeTruthy()
+    expect(screen.getByText('Wallet connections unavailable')).toBeTruthy()
   })
 })

--- a/packages/openfort-react/src/__tests__/pages/WalletConnectNotConfigured.test.tsx
+++ b/packages/openfort-react/src/__tests__/pages/WalletConnectNotConfigured.test.tsx
@@ -1,0 +1,91 @@
+import { ChainTypeEnum } from '@openfort/openfort-js'
+import { fireEvent, render, renderHook, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { routes } from '../../components/Openfort/types'
+
+/**
+ * When no WalletConnect projectId is configured (missing env variable),
+ * WalletConnect-dependent pages must show a clear configuration message
+ * with a way back to sign-in — not an infinite spinner.
+ */
+
+const setRoute = vi.fn()
+
+let bridgeValue: { connectors: { id: string }[] } | null = null
+
+vi.mock('../../components/Openfort/useOpenfort', () => ({
+  useOpenfort: () => ({
+    setRoute,
+    setConnector: vi.fn(),
+    connector: { id: 'metaMask' },
+    chainType: ChainTypeEnum.EVM,
+    uiConfig: {},
+    triggerResize: vi.fn(),
+    setOnBack: vi.fn(),
+    setPreviousRoute: vi.fn(),
+    setRouteHistory: vi.fn(),
+  }),
+}))
+vi.mock('../../ethereum/OpenfortEthereumBridgeContext', () => ({ useEthereumBridge: () => bridgeValue }))
+vi.mock('../../core/ConnectionStrategyContext', () => ({ useConnectionStrategy: () => null }))
+vi.mock('../../hooks/openfort/auth/useSignOut', () => ({ useSignOut: () => ({ signOut: vi.fn() }) }))
+// FitText measures DOM sizes that jsdom cannot provide
+vi.mock('../../components/Common/FitText', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+const { default: WalletConnectNotConfigured, useHasWalletConnect } = await import(
+  '../../components/Common/WalletConnectNotConfigured'
+)
+const { default: MobileConnectors } = await import('../../components/Pages/MobileConnectors')
+
+describe('useHasWalletConnect', () => {
+  it('is false without a bridge (embedded-only)', () => {
+    bridgeValue = null
+    const { result } = renderHook(() => useHasWalletConnect())
+    expect(result.current).toBe(false)
+  })
+
+  it('is false when no walletConnect connector is configured', () => {
+    bridgeValue = { connectors: [{ id: 'coinbaseWalletSDK' }, { id: 'injected' }] }
+    const { result } = renderHook(() => useHasWalletConnect())
+    expect(result.current).toBe(false)
+  })
+
+  it('is true when a walletConnect connector exists', () => {
+    bridgeValue = { connectors: [{ id: 'walletConnect' }] }
+    const { result } = renderHook(() => useHasWalletConnect())
+    expect(result.current).toBe(true)
+  })
+})
+
+describe('WalletConnectNotConfigured page', () => {
+  beforeEach(() => {
+    setRoute.mockClear()
+  })
+
+  it('explains the missing WalletConnect project ID', () => {
+    render(<WalletConnectNotConfigured />)
+
+    expect(screen.getByText('WalletConnect is not configured')).toBeTruthy()
+    expect(screen.getByText(/project ID environment variable/i)).toBeTruthy()
+  })
+
+  it('"Back to sign in" routes to the providers (sign-in) page', () => {
+    render(<WalletConnectNotConfigured />)
+
+    fireEvent.click(screen.getByText('Back to sign in'))
+
+    expect(setRoute).toHaveBeenCalledWith(routes.PROVIDERS)
+  })
+})
+
+describe('MobileConnectors without WalletConnect', () => {
+  it('shows the configuration page instead of the wallet list', () => {
+    bridgeValue = { connectors: [{ id: 'injected' }] }
+
+    render(<MobileConnectors />)
+
+    expect(screen.getByText('WalletConnect is not configured')).toBeTruthy()
+  })
+})

--- a/packages/openfort-react/src/components/Common/ErrorFallbackPage/index.tsx
+++ b/packages/openfort-react/src/components/Common/ErrorFallbackPage/index.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useOpenfortCore } from '../../../openfort/useOpenfort'
+import { routes } from '../../Openfort/types'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+import { PageContent } from '../../PageContent'
+import Button from '../Button'
+import Loader from '../Loading'
+
+type ErrorFallbackPageProps = {
+  header: string
+  description: string
+}
+
+/** Shared error page with a single way out: back to the providers (sign-in) screen. */
+const ErrorFallbackPage = ({ header, description }: ErrorFallbackPageProps) => {
+  const { setRoute } = useOpenfort()
+  const { user } = useOpenfortCore()
+
+  return (
+    <PageContent onBack={routes.PROVIDERS}>
+      <Loader header={header} isError description={description} />
+      <Button onClick={() => setRoute(routes.PROVIDERS)}>{user ? 'Go back' : 'Back to sign in'}</Button>
+    </PageContent>
+  )
+}
+
+export default ErrorFallbackPage

--- a/packages/openfort-react/src/components/Common/NotFoundFallback/index.tsx
+++ b/packages/openfort-react/src/components/Common/NotFoundFallback/index.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { routes } from '../../Openfort/types'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+import { PageContent } from '../../PageContent'
+import Button from '../Button'
+import Loader from '../Loading'
+
+/**
+ * Catch-all page for flows that would otherwise spin forever
+ * (loading watchdog timeouts, unreachable states).
+ */
+const NotFoundFallback = () => {
+  const { setRoute } = useOpenfort()
+
+  return (
+    <PageContent onBack={routes.PROVIDERS}>
+      <Loader
+        header="We couldn't find what you're looking for"
+        isError
+        description="This is taking longer than expected. Go back to sign in and try again."
+      />
+      <Button onClick={() => setRoute(routes.PROVIDERS)}>Back to sign in</Button>
+    </PageContent>
+  )
+}
+
+export default NotFoundFallback

--- a/packages/openfort-react/src/components/Common/NotFoundFallback/index.tsx
+++ b/packages/openfort-react/src/components/Common/NotFoundFallback/index.tsx
@@ -1,28 +1,16 @@
 'use client'
 
-import { routes } from '../../Openfort/types'
-import { useOpenfort } from '../../Openfort/useOpenfort'
-import { PageContent } from '../../PageContent'
-import Button from '../Button'
-import Loader from '../Loading'
+import ErrorFallbackPage from '../ErrorFallbackPage'
 
 /**
  * Catch-all page for flows that would otherwise spin forever
  * (loading watchdog timeouts, unreachable states).
  */
-const NotFoundFallback = () => {
-  const { setRoute } = useOpenfort()
-
-  return (
-    <PageContent onBack={routes.PROVIDERS}>
-      <Loader
-        header="We couldn't find what you're looking for"
-        isError
-        description="This is taking longer than expected. Go back to sign in and try again."
-      />
-      <Button onClick={() => setRoute(routes.PROVIDERS)}>Back to sign in</Button>
-    </PageContent>
-  )
-}
+const NotFoundFallback = () => (
+  <ErrorFallbackPage
+    header="This is taking longer than expected"
+    description="We couldn't load this screen. Go back and try again."
+  />
+)
 
 export default NotFoundFallback

--- a/packages/openfort-react/src/components/Common/WalletConnectNotConfigured/index.tsx
+++ b/packages/openfort-react/src/components/Common/WalletConnectNotConfigured/index.tsx
@@ -1,12 +1,9 @@
 'use client'
 
+import { useEffect } from 'react'
 import { useEthereumBridge } from '../../../ethereum/OpenfortEthereumBridgeContext'
 import { isWalletConnectConnector } from '../../../utils'
-import { routes } from '../../Openfort/types'
-import { useOpenfort } from '../../Openfort/useOpenfort'
-import { PageContent } from '../../PageContent'
-import Button from '../Button'
-import Loader from '../Loading'
+import ErrorFallbackPage from '../ErrorFallbackPage'
 
 /** True when a WalletConnect connector is configured (i.e. a projectId was provided). */
 export function useHasWalletConnect(): boolean {
@@ -16,20 +13,22 @@ export function useHasWalletConnect(): boolean {
 
 /**
  * Shown when a WalletConnect-dependent flow is opened but no WalletConnect
- * projectId was configured (e.g. the WalletConnect env variable is missing).
+ * projectId was configured. End users get neutral copy; the actionable
+ * config hint goes to the developer console.
  */
 const WalletConnectNotConfigured = () => {
-  const { setRoute } = useOpenfort()
+  useEffect(() => {
+    // biome-ignore lint/suspicious/noConsole: config error must reach developers without debug mode
+    console.warn(
+      '[Openfort-React] WalletConnect is not configured: pass walletConnectProjectId to getDefaultConnectors (e.g. via your WalletConnect env variable) to enable external wallet connections.'
+    )
+  }, [])
 
   return (
-    <PageContent onBack={routes.PROVIDERS}>
-      <Loader
-        header="WalletConnect is not configured"
-        isError
-        description="Set your WalletConnect project ID environment variable to enable external wallet connections."
-      />
-      <Button onClick={() => setRoute(routes.PROVIDERS)}>Back to sign in</Button>
-    </PageContent>
+    <ErrorFallbackPage
+      header="Wallet connections unavailable"
+      description="External wallet connections aren't available right now. Please use another sign-in method."
+    />
   )
 }
 

--- a/packages/openfort-react/src/components/Common/WalletConnectNotConfigured/index.tsx
+++ b/packages/openfort-react/src/components/Common/WalletConnectNotConfigured/index.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useEthereumBridge } from '../../../ethereum/OpenfortEthereumBridgeContext'
+import { isWalletConnectConnector } from '../../../utils'
+import { routes } from '../../Openfort/types'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+import { PageContent } from '../../PageContent'
+import Button from '../Button'
+import Loader from '../Loading'
+
+/** True when a WalletConnect connector is configured (i.e. a projectId was provided). */
+export function useHasWalletConnect(): boolean {
+  const bridge = useEthereumBridge()
+  return !!bridge?.connectors.some((c) => isWalletConnectConnector(c.id))
+}
+
+/**
+ * Shown when a WalletConnect-dependent flow is opened but no WalletConnect
+ * projectId was configured (e.g. the WalletConnect env variable is missing).
+ */
+const WalletConnectNotConfigured = () => {
+  const { setRoute } = useOpenfort()
+
+  return (
+    <PageContent onBack={routes.PROVIDERS}>
+      <Loader
+        header="WalletConnect is not configured"
+        isError
+        description="Set your WalletConnect project ID environment variable to enable external wallet connections."
+      />
+      <Button onClick={() => setRoute(routes.PROVIDERS)}>Back to sign in</Button>
+    </PageContent>
+  )
+}
+
+export default WalletConnectNotConfigured

--- a/packages/openfort-react/src/components/ConnectModal/ConnectWithMobile.tsx
+++ b/packages/openfort-react/src/components/ConnectModal/ConnectWithMobile.tsx
@@ -12,6 +12,7 @@ import { walletConfigs } from '../../wallets/walletConfigs'
 import Button from '../Common/Button'
 import FitText from '../Common/FitText'
 import Loader from '../Common/Loading'
+import WalletConnectNotConfigured, { useHasWalletConnect } from '../Common/WalletConnectNotConfigured'
 import { routes } from '../Openfort/types'
 import { useOpenfort } from '../Openfort/useOpenfort'
 import { PageContent } from '../PageContent'
@@ -42,6 +43,7 @@ const ConnectWithMobile: React.FC = () => {
 
   const wallet = useExternalConnector(connector.id) || (walletId && walletConfigs[walletId]) || {}
   const bridge = useEthereumBridge()
+  const hasWalletConnect = useHasWalletConnect()
   // Only consider external wallets as "connected" — ignore the embedded wallet connector
   const isExternalConnected =
     (bridge?.account?.isConnected && bridge?.account?.connector?.id !== embeddedWalletId) ?? false
@@ -98,6 +100,8 @@ const ConnectWithMobile: React.FC = () => {
         break
     }
   }, [status])
+
+  if (!hasWalletConnect) return <WalletConnectNotConfigured />
 
   return (
     <PageContent>

--- a/packages/openfort-react/src/components/ConnectModal/ConnectWithQRCode.tsx
+++ b/packages/openfort-react/src/components/ConnectModal/ConnectWithQRCode.tsx
@@ -9,6 +9,7 @@ import { useExternalConnector } from '../../wallets/useExternalConnectors'
 import { CopyText } from '../Common/CopyToClipboard/CopyText'
 import Loader from '../Common/Loading'
 import { ModalBody } from '../Common/Modal/styles'
+import WalletConnectNotConfigured, { useHasWalletConnect } from '../Common/WalletConnectNotConfigured'
 import { routes } from '../Openfort/types'
 import { useOpenfort } from '../Openfort/useOpenfort'
 import { PageContent } from '../PageContent'
@@ -61,6 +62,7 @@ const ConnectWithWalletConnect = () => {
   const { connector } = useOpenfort()
   const wallet = useExternalConnector(connector.id)
   const { open: openWalletConnectModal } = useWalletConnectModal()
+  const hasWalletConnect = useHasWalletConnect()
   const [error, setError] = useState<string | undefined>(undefined)
   const hasOpenedRef = useRef(false)
 
@@ -71,10 +73,13 @@ const ConnectWithWalletConnect = () => {
   }, [openWalletConnectModal])
 
   useEffect(() => {
+    if (!hasWalletConnect) return
     if (hasOpenedRef.current) return
     hasOpenedRef.current = true
     openModal()
-  }, [openModal])
+  }, [openModal, hasWalletConnect])
+
+  if (!hasWalletConnect) return <WalletConnectNotConfigured />
 
   return (
     <PageContent>

--- a/packages/openfort-react/src/components/Pages/LoadWallets/index.tsx
+++ b/packages/openfort-react/src/components/Pages/LoadWallets/index.tsx
@@ -10,6 +10,7 @@ import { useSolanaEmbeddedWallet } from '../../../solana/hooks/useSolanaEmbedded
 import type { ConnectedEmbeddedSolanaWallet } from '../../../solana/types'
 import { logger } from '../../../utils/logger'
 import Loader from '../../Common/Loading'
+import NotFoundFallback from '../../Common/NotFoundFallback'
 import { createRoute, recoverRoute } from '../../Openfort/routeHelpers'
 import { routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
@@ -49,6 +50,10 @@ const errorForChainRegistry: Record<
   }),
 }
 
+// Watchdog: if wallet loading never settles (hung fetch, unreachable state),
+// bail out to the not-found fallback instead of spinning forever.
+const LOADING_TIMEOUT_MS = 10_000
+
 const LoadWallets: React.FC = () => {
   const { chainType, user, isLoadingAccounts } = useOpenfortCore()
   const { triggerResize, setRoute, setConnector, walletConfig } = useOpenfort()
@@ -58,6 +63,12 @@ const LoadWallets: React.FC = () => {
   const connectOnLogin = walletConfig?.connectOnLogin ?? true
 
   const [loadingUX, setLoadingUX] = useState(true)
+  const [timedOut, setTimedOut] = useState(false)
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setTimedOut(true), LOADING_TIMEOUT_MS)
+    return () => clearTimeout(timeout)
+  }, [])
 
   const wallets = embeddedWallet.wallets
   const isLoadingWallets =
@@ -122,6 +133,9 @@ const LoadWallets: React.FC = () => {
   const { isError: isErrorFromChain, message: errorMessageFromChain } = errorForChainRegistry[chainType](errorWallets)
   const isError = !user || isErrorFromChain
   const errorMessage = !user ? undefined : errorMessageFromChain
+
+  // Only fall back while still spinning — real errors keep their own message
+  if (timedOut && !isError) return <NotFoundFallback />
 
   return (
     <PageContent onBack={!user ? 'back' : null}>

--- a/packages/openfort-react/src/components/Pages/LoadWallets/index.tsx
+++ b/packages/openfort-react/src/components/Pages/LoadWallets/index.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { useEthereumEmbeddedWallet } from '../../../ethereum/hooks/useEthereumEmbeddedWallet'
 import type { ConnectedEmbeddedEthereumWallet } from '../../../ethereum/types'
 import { toSolanaUserWallet } from '../../../hooks/openfort/walletTypes'
+import { useTimedOut } from '../../../hooks/useTimedOut'
 import { useOpenfortCore } from '../../../openfort/useOpenfort'
 import { useSolanaEmbeddedWallet } from '../../../solana/hooks/useSolanaEmbeddedWallet'
 import type { ConnectedEmbeddedSolanaWallet } from '../../../solana/types'
@@ -63,12 +64,7 @@ const LoadWallets: React.FC = () => {
   const connectOnLogin = walletConfig?.connectOnLogin ?? true
 
   const [loadingUX, setLoadingUX] = useState(true)
-  const [timedOut, setTimedOut] = useState(false)
-
-  useEffect(() => {
-    const timeout = setTimeout(() => setTimedOut(true), LOADING_TIMEOUT_MS)
-    return () => clearTimeout(timeout)
-  }, [])
+  const timedOut = useTimedOut(LOADING_TIMEOUT_MS)
 
   const wallets = embeddedWallet.wallets
   const isLoadingWallets =

--- a/packages/openfort-react/src/components/Pages/Loading/index.tsx
+++ b/packages/openfort-react/src/components/Pages/Loading/index.tsx
@@ -4,6 +4,7 @@ import { ChainTypeEnum, EmbeddedState } from '@openfort/openfort-js'
 import React, { useEffect } from 'react'
 import { useEthereumEmbeddedWallet } from '../../../ethereum/hooks/useEthereumEmbeddedWallet'
 import { useEthereumBridge } from '../../../ethereum/OpenfortEthereumBridgeContext'
+import { useTimedOut } from '../../../hooks/useTimedOut'
 import { useOpenfortCore } from '../../../openfort/useOpenfort'
 import { useSolanaEmbeddedWallet } from '../../../solana/hooks/useSolanaEmbeddedWallet'
 import Loader from '../../Common/Loading'
@@ -34,12 +35,7 @@ const Loading: React.FC = () => {
 
   const [isFirstFrame, setIsFirstFrame] = React.useState(true)
   const [retryCount, setRetryCount] = React.useState(0)
-  const [timedOut, setTimedOut] = React.useState(false)
-
-  useEffect(() => {
-    const timeout = setTimeout(() => setTimedOut(true), LOADING_TIMEOUT_MS)
-    return () => clearTimeout(timeout)
-  }, [])
+  const timedOut = useTimedOut(LOADING_TIMEOUT_MS)
 
   useEffect(() => {
     if (isFirstFrame) return

--- a/packages/openfort-react/src/components/Pages/Loading/index.tsx
+++ b/packages/openfort-react/src/components/Pages/Loading/index.tsx
@@ -7,9 +7,14 @@ import { useEthereumBridge } from '../../../ethereum/OpenfortEthereumBridgeConte
 import { useOpenfortCore } from '../../../openfort/useOpenfort'
 import { useSolanaEmbeddedWallet } from '../../../solana/hooks/useSolanaEmbeddedWallet'
 import Loader from '../../Common/Loading'
+import NotFoundFallback from '../../Common/NotFoundFallback'
 import { routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
+
+// Watchdog: if no state transition routes us away within this window, the modal
+// would otherwise spin forever (e.g. opened while signed out, or a misconfigured SDK).
+const LOADING_TIMEOUT_MS = 10_000
 
 const Loading: React.FC = () => {
   const { setRoute, walletConfig } = useOpenfort()
@@ -29,6 +34,12 @@ const Loading: React.FC = () => {
 
   const [isFirstFrame, setIsFirstFrame] = React.useState(true)
   const [retryCount, setRetryCount] = React.useState(0)
+  const [timedOut, setTimedOut] = React.useState(false)
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setTimedOut(true), LOADING_TIMEOUT_MS)
+    return () => clearTimeout(timeout)
+  }, [])
 
   useEffect(() => {
     if (isFirstFrame) return
@@ -63,6 +74,8 @@ const Loading: React.FC = () => {
     // UX: Wait a bit before showing the next page
     setTimeout(() => setIsFirstFrame(false), 400)
   }, [])
+
+  if (timedOut) return <NotFoundFallback />
 
   return (
     <PageContent>

--- a/packages/openfort-react/src/components/Pages/MobileConnectors/index.tsx
+++ b/packages/openfort-react/src/components/Pages/MobileConnectors/index.tsx
@@ -7,6 +7,7 @@ import { CopyButton } from '../../Common/CopyToClipboard/CopyButton'
 import { ModalContent } from '../../Common/Modal/styles'
 import { ScrollArea } from '../../Common/ScrollArea'
 import { Spinner } from '../../Common/Spinner'
+import WalletConnectNotConfigured, { useHasWalletConnect } from '../../Common/WalletConnectNotConfigured'
 import { routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
@@ -25,6 +26,7 @@ const MobileConnectors: React.FC = () => {
 
   const { open: openW3M, isOpen: isOpenW3M } = useWalletConnectModal()
   const wallets = useExternalConnectors()
+  const hasWalletConnect = useHasWalletConnect()
 
   // filter out installed wallets
   const walletsIdsToDisplay =
@@ -39,6 +41,9 @@ const MobileConnectors: React.FC = () => {
     context.setRoute(routes.CONNECT_WITH_MOBILE)
     context.setConnector({ id: walletId })
   }
+
+  // Every wallet on this page connects through WalletConnect deeplinks
+  if (!hasWalletConnect) return <WalletConnectNotConfigured />
 
   return (
     <PageContent width={312} onBack={routes.PROVIDERS}>

--- a/packages/openfort-react/src/hooks/openfort/useUI.ts
+++ b/packages/openfort-react/src/hooks/openfort/useUI.ts
@@ -30,9 +30,14 @@ const safeRoutes: {
   ],
 }
 
-const allRoutes: ModalRoutes[] = [...safeRoutes.connected, ...safeRoutes.disconnected]
-
 type ValidRoutes = ModalRoutes
+
+/** Route can be selected by string (route name) or by object with `route` property */
+function routeMatches(a: ModalRoutes, b: ModalRoutes): boolean {
+  const aRoute = typeof a === 'object' && a !== null && 'route' in a ? a.route : a
+  const bRoute = typeof b === 'object' && b !== null && 'route' in b ? b.route : b
+  return aRoute === bRoute
+}
 
 /** Connector id must be a connector (e.g. injected, walletConnect), not an Openfort account id. */
 function isAccountId(id: string): boolean {
@@ -98,27 +103,23 @@ export function useUI() {
   }
 
   const gotoAndOpen = (route: ValidRoutes) => {
-    let validRoute: ValidRoutes = route
+    const safeList = isConnected ? safeRoutes.connected : safeRoutes.disconnected
+    const fallback = isConnected ? routes.CONNECTED : routes.PROVIDERS
 
-    if (!allRoutes.includes(route)) {
-      validRoute = isConnected ? routes.CONNECTED : routes.PROVIDERS
-      logger.log(`Route ${route} is not a valid route, navigating to ${validRoute} instead.`)
-    } else {
-      if (isConnected) {
-        if (!safeRoutes.connected.includes(route)) {
-          validRoute = routes.CONNECTED
-          logger.log(`Route ${route} is not a valid route when connected, navigating to ${validRoute} instead.`)
-        }
-      } else {
-        if (!safeRoutes.disconnected.includes(route)) {
-          validRoute = routes.PROVIDERS
-          logger.log(`Route ${route} is not a valid route when disconnected, navigating to ${validRoute} instead.`)
-        }
-      }
+    // Navigate using the allowlisted spec so vetted options (e.g. connectType) are enforced,
+    // not whatever the caller passed alongside a matching route name.
+    const match = safeList.find((r) => routeMatches(r, route))
+
+    if (!match) {
+      logger.log(
+        `Route ${JSON.stringify(route)} is not valid when ${isConnected ? 'connected' : 'disconnected'}, navigating to ${fallback} instead.`
+      )
     }
 
-    setRoute(validRoute)
+    // setOpen(true) resets route/history/connector for a clean session, so it MUST run
+    // before setRoute — otherwise it clobbers the requested route back to LOADING.
     setOpen(true)
+    setRoute(match ?? fallback)
   }
 
   return {

--- a/packages/openfort-react/src/hooks/useTimedOut.ts
+++ b/packages/openfort-react/src/hooks/useTimedOut.ts
@@ -1,0 +1,15 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/** Returns true once `ms` milliseconds have elapsed since mount. */
+export function useTimedOut(ms: number): boolean {
+  const [timedOut, setTimedOut] = useState(false)
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setTimedOut(true), ms)
+    return () => clearTimeout(timeout)
+  }, [ms])
+
+  return timedOut
+}


### PR DESCRIPTION
Restore gotoAndOpen fix , Add WC-not-configured page and loading watchdogs

- Restore lost merge fix: setOpen(true) resets route to LOADING, so gotoAndOpen must open before routing; match route specs by name
- Add WalletConnectNotConfigured page with back-to-sign-in button, shown by WC-dependent pages when no projectId is configured
- Add 10s watchdog to Loading and LoadWallets pages that falls back to a NotFoundFallback page instead of spinning forever