### PR TITLE
feat(solana): Send flow for embedded wallets

### DIFF
--- a/packages/openfort-react/package.json
+++ b/packages/openfort-react/package.json
@@ -91,7 +91,9 @@
     "@coinbase/wallet-sdk": "^4.3.6",
     "@safe-global/safe-apps-provider": "~0.18.6",
     "@safe-global/safe-apps-sdk": "^9.1.0",
+    "@solana-program/system": "^0.10.0",
     "@solana/kit": "^2.0.0 || ^5.0.0",
+    "@solana/kora": "^0.1.1",
     "@walletconnect/ethereum-provider": "^2.21.1",
     "react": "17.x || 18.x || 19.x",
     "react-dom": "17.x || 18.x || 19.x",
@@ -124,7 +126,13 @@
     "wagmi": "^3.6.16"
   },
   "peerDependenciesMeta": {
+    "@solana-program/system": {
+      "optional": true
+    },
     "@solana/kit": {
+      "optional": true
+    },
+    "@solana/kora": {
       "optional": true
     },
     "wagmi": {

--- a/packages/openfort-react/src/components/ConnectModal/index.tsx
+++ b/packages/openfort-react/src/components/ConnectModal/index.tsx
@@ -55,7 +55,9 @@ import RemoveLinkedProvider from '../Pages/RemoveLinkedProvider'
 import SelectToken from '../Pages/SelectToken'
 import SelectWalletToRecover from '../Pages/SelectWalletToRecover'
 import Send from '../Pages/Send'
+import { SolanaSend } from '../Pages/Send/SolanaSend'
 import SendConfirmation from '../Pages/SendConfirmation'
+import { SolanaSendConfirmation } from '../Pages/SendConfirmation/SolanaSendConfirmation'
 import SocialProviders from '../Pages/SocialProviders'
 import ConnectUsing from './ConnectUsing'
 import ConnectWithMobile from './ConnectWithMobile'
@@ -131,8 +133,8 @@ const CHAIN_PREFIXED_PAGES: Record<ChainTypeEnum, RoutePages> = {
     'sol:connected': <Connected />,
     'sol:createWallet': <CreateWallet />,
     'sol:recoverWallet': <RecoverPage />,
-    // 'sol:send': <SolanaSend />,
-    // 'sol:sendConfirmation': <SolanaSendConfirmation />,
+    'sol:send': <SolanaSend />,
+    'sol:sendConfirmation': <SolanaSendConfirmation />,
     'sol:receive': <Receive />,
     // 'sol:wallets': <SolanaWallets />,
   },

--- a/packages/openfort-react/src/components/Pages/Connected/SolanaConnected.tsx
+++ b/packages/openfort-react/src/components/Pages/Connected/SolanaConnected.tsx
@@ -10,7 +10,7 @@
 import { ChainTypeEnum } from '@openfort/openfort-js'
 import type React from 'react'
 import { useEffect } from 'react'
-import { ReceiveIcon, UserRoundIcon } from '../../../assets/icons'
+import { ReceiveIcon, SendIcon, UserRoundIcon } from '../../../assets/icons'
 import { BALANCE_INVALIDATE_EVENT, fetchSolanaBalance } from '../../../hooks/useBalance'
 import useLocales from '../../../hooks/useLocales'
 import { useOpenfortCore } from '../../../openfort/useOpenfort'
@@ -132,9 +132,14 @@ const SolanaConnected: React.FC = () => {
         avatar={avatar}
         balance={balanceNode}
         actions={
-          <ActionButton icon={<ReceiveIcon />} onClick={() => context.setRoute(routes.DEPOSIT)}>
-            Deposit
-          </ActionButton>
+          <>
+            <ActionButton icon={<SendIcon />} onClick={() => context.setRoute(routes.SOL_SEND)}>
+              Send
+            </ActionButton>
+            <ActionButton icon={<ReceiveIcon />} onClick={() => context.setRoute(routes.DEPOSIT)}>
+              Deposit
+            </ActionButton>
+          </>
         }
         hideBalance={context?.uiConfig.hideBalance}
         isBalanceLoading={isBalanceLoading}

--- a/packages/openfort-react/src/components/Pages/Connected/SolanaConnected.tsx
+++ b/packages/openfort-react/src/components/Pages/Connected/SolanaConnected.tsx
@@ -133,7 +133,14 @@ const SolanaConnected: React.FC = () => {
         balance={balanceNode}
         actions={
           <>
-            <ActionButton icon={<SendIcon />} onClick={() => context.setRoute(routes.SOL_SEND)}>
+            <ActionButton
+              icon={<SendIcon />}
+              onClick={() => {
+                // Nothing to send on an empty wallet — prompt to add funds first (mirrors EVM).
+                const hasBalance = lamports != null && BigInt(lamports) > BigInt(0)
+                context.setRoute(hasBalance ? routes.SOL_SEND : routes.NO_ASSETS_AVAILABLE)
+              }}
+            >
               Send
             </ActionButton>
             <ActionButton icon={<ReceiveIcon />} onClick={() => context.setRoute(routes.DEPOSIT)}>

--- a/packages/openfort-react/src/components/Pages/Send/SolanaSend.tsx
+++ b/packages/openfort-react/src/components/Pages/Send/SolanaSend.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+/**
+ * Solana Send page
+ *
+ * Native SOL transfer form. Single fixed asset (SOL) — no token picker. Mirrors
+ * EthereumSend's validation/Max behaviour; the actual transfer happens on the
+ * SolanaSendConfirmation page.
+ */
+
+import { useMemo } from 'react'
+import { formatUnits, parseUnits } from 'viem'
+import { fetchSolanaBalance } from '../../../hooks/useBalance'
+import { useAsyncData } from '../../../shared/hooks/useAsyncData'
+import { useSolanaEmbeddedWallet } from '../../../solana/hooks/useSolanaEmbeddedWallet'
+import Button from '../../Common/Button'
+import Input from '../../Common/Input'
+import { ModalHeading } from '../../Common/Modal/styles'
+import { routes, type SendFormState } from '../../Openfort/types'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+import { PageContent } from '../../PageContent'
+import { AmountInputWrapper, ErrorText, Field, FieldLabel, Form, HelperText, MaxButton } from './styles'
+import { formatBalance, sanitizeAmountInput, sanitizeForParsing } from './utils'
+
+const SOL_DECIMALS = 9
+
+/** Cheap base58 shape check for the form; the RPC validates the real address on send. */
+function isLikelySolanaAddress(value: string): boolean {
+  return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value)
+}
+
+export const SolanaSend = () => {
+  const { sendForm, setSendForm, setRoute } = useOpenfort()
+  const wallet = useSolanaEmbeddedWallet()
+  const address = wallet.status === 'connected' ? wallet.address : undefined
+  const rpcUrl = wallet.rpcUrl
+
+  const balanceResult = useAsyncData({
+    queryKey: ['solana-balance', address, rpcUrl],
+    queryFn: async () => {
+      if (!address || !rpcUrl) return null
+      const { value } = await fetchSolanaBalance(address, rpcUrl, 'confirmed')
+      return value
+    },
+    enabled: Boolean(address && rpcUrl),
+  })
+  const balanceLamports = balanceResult.data ?? undefined
+
+  const parsedAmount = useMemo(() => {
+    const raw = sanitizeForParsing(sendForm.amount)
+    if (!raw) return null
+    try {
+      return parseUnits(raw, SOL_DECIMALS)
+    } catch {
+      return null
+    }
+  }, [sendForm.amount])
+
+  const recipientValid = isLikelySolanaAddress(sendForm.recipient.trim())
+  const insufficientBalance =
+    parsedAmount !== null && balanceLamports !== undefined ? parsedAmount > balanceLamports : false
+  const amountValid = parsedAmount !== null && parsedAmount > BigInt(0) && !insufficientBalance
+  const canProceed = recipientValid && amountValid
+
+  const availableLabel = formatBalance(balanceLamports, SOL_DECIMALS)
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!canProceed) return
+    const normalized = sanitizeForParsing(sendForm.amount)
+    if (!normalized) return
+    setSendForm((prev: SendFormState) => ({
+      ...prev,
+      recipient: prev.recipient.trim(),
+      amount: normalized,
+      asset: {
+        type: 'native',
+        balance: balanceLamports ?? BigInt(0),
+        metadata: { symbol: 'SOL', decimals: SOL_DECIMALS, fiat: { value: 0, currency: 'USD' } },
+      },
+    }))
+    setRoute(routes.SOL_SEND_CONFIRMATION)
+  }
+
+  const handleAmountChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = sanitizeAmountInput(event.target.value)
+    if (raw === '' || /^[0-9]*\.?[0-9]*$/.test(raw)) {
+      setSendForm((prev) => ({ ...prev, amount: raw }))
+    }
+  }
+
+  const handleMax = () => {
+    if (balanceLamports === undefined) return
+    setSendForm((prev) => ({ ...prev, amount: formatUnits(balanceLamports, SOL_DECIMALS) }))
+  }
+
+  return (
+    <PageContent onBack={routes.SOL_CONNECTED}>
+      <ModalHeading>Send SOL</ModalHeading>
+      <Form onSubmit={handleSubmit}>
+        <Field>
+          <FieldLabel>Amount</FieldLabel>
+          <AmountInputWrapper>
+            <Input
+              placeholder="0.00"
+              value={sendForm.amount}
+              onChange={handleAmountChange}
+              inputMode="decimal"
+              autoComplete="off"
+              style={{ paddingRight: '86px' }}
+            />
+            <MaxButton type="button" onClick={handleMax} disabled={balanceLamports === undefined}>
+              Max
+            </MaxButton>
+          </AmountInputWrapper>
+          <HelperText>Available: {availableLabel} SOL</HelperText>
+          {sendForm.amount && parsedAmount === null && <ErrorText>Enter a valid amount.</ErrorText>}
+          {insufficientBalance && <ErrorText>Insufficient SOL balance for this transfer.</ErrorText>}
+        </Field>
+
+        <Field>
+          <FieldLabel>Recipient address</FieldLabel>
+          <Input
+            placeholder="Solana address"
+            value={sendForm.recipient}
+            onChange={(e) => setSendForm((prev) => ({ ...prev, recipient: e.target.value }))}
+            autoComplete="off"
+          />
+          {sendForm.recipient && !recipientValid && <ErrorText>Enter a valid Solana address.</ErrorText>}
+        </Field>
+
+        <Button variant="primary" disabled={!canProceed}>
+          Review transfer
+        </Button>
+      </Form>
+    </PageContent>
+  )
+}

--- a/packages/openfort-react/src/components/Pages/Send/index.tsx
+++ b/packages/openfort-react/src/components/Pages/Send/index.tsx
@@ -1,7 +1,8 @@
 /**
  * Send page router
  *
- * Picks EthereumSend or SolanaSend based on chainType.
+ * Renders the EVM send form. Solana is reached via the dedicated `sol:send`
+ * route (registered in ConnectModal), so it isn't in this shared registry.
  */
 
 import { ChainTypeEnum } from '@openfort/openfort-js'
@@ -11,7 +12,6 @@ import { EthereumSend } from './EthereumSend'
 
 const SEND_REGISTRY: Partial<Record<ChainTypeEnum, React.FC>> = {
   [ChainTypeEnum.EVM]: EthereumSend,
-  // [ChainTypeEnum.SVM]: SolanaSend,
 }
 
 const Send: React.FC = () => {

--- a/packages/openfort-react/src/components/Pages/SendConfirmation/SolanaSendConfirmation.tsx
+++ b/packages/openfort-react/src/components/Pages/SendConfirmation/SolanaSendConfirmation.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+/**
+ * Solana Send confirmation page
+ *
+ * Reviews the SOL transfer from `sendForm`, optionally sponsors the fee through
+ * the Openfort Solana paymaster (Kora), submits via `sendSol` / `sendSolGasless`,
+ * and shows the signature + explorer link on success.
+ */
+
+import { ChainTypeEnum } from '@openfort/openfort-js'
+import { useEffect, useState } from 'react'
+import { getExplorerUrl } from '../../../shared/utils/explorer'
+import { useSolanaEmbeddedWallet } from '../../../solana/hooks/useSolanaEmbeddedWallet'
+import { sendSol, sendSolGasless } from '../../../solana/transfer'
+import { truncateSolanaAddress } from '../../../utils'
+import Button from '../../Common/Button'
+import { CopyText } from '../../Common/CopyToClipboard/CopyText'
+import Loader from '../../Common/Loading'
+import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
+import { routes } from '../../Openfort/types'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+import { PageContent } from '../../PageContent'
+import {
+  AddressValue,
+  AmountValue,
+  ButtonRow,
+  ErrorContainer,
+  ErrorMessage,
+  ErrorTitle,
+  GaslessRow,
+  GaslessToggle,
+  SummaryItem,
+  SummaryLabel,
+  SummaryList,
+} from './styles'
+
+export const SolanaSendConfirmation = () => {
+  const { sendForm, setRoute, publishableKey, triggerResize } = useOpenfort()
+  const wallet = useSolanaEmbeddedWallet()
+
+  const address = wallet.status === 'connected' ? wallet.address : undefined
+  const provider = wallet.status === 'connected' ? wallet.provider : undefined
+  const cluster = wallet.cluster ?? 'devnet'
+  const rpcUrl = wallet.rpcUrl
+
+  const recipient = sendForm.recipient
+  const amount = sendForm.amount
+
+  const [gasless, setGasless] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [signature, setSignature] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // Re-measure the modal when the result/error appears.
+  useEffect(() => {
+    const id = setTimeout(triggerResize, 10)
+    return () => clearTimeout(id)
+  }, [signature, error, isLoading, triggerResize])
+
+  const handleConfirm = async () => {
+    if (!address || !provider || isLoading) return
+    const amountSol = Number(amount)
+    if (!Number.isFinite(amountSol) || amountSol <= 0) {
+      setError('Enter a valid amount.')
+      return
+    }
+    if (!gasless && !rpcUrl) {
+      setError('No Solana RPC is configured for this network.')
+      return
+    }
+    setIsLoading(true)
+    setError(null)
+    try {
+      const sig = gasless
+        ? await sendSolGasless({ from: address, to: recipient, amountSol, provider, cluster, publishableKey })
+        : await sendSol({ from: address, to: recipient, amountSol, provider, rpcUrl: rpcUrl ?? '' })
+      setSignature(sig)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Transaction failed')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleFinish = () => setRoute(routes.SOL_CONNECTED)
+  const handleViewExplorer = () => {
+    if (!signature) return
+    window.open(getExplorerUrl(ChainTypeEnum.SVM, { txHash: signature, cluster }), '_blank', 'noopener,noreferrer')
+  }
+
+  if (signature) {
+    return (
+      <PageContent>
+        <Loader isSuccess header="Transfer sent" description={`${amount} SOL sent successfully`} />
+        <ButtonRow>
+          <Button variant="primary" onClick={handleViewExplorer}>
+            View on Explorer
+          </Button>
+          <Button variant="secondary" onClick={handleFinish}>
+            Back to profile
+          </Button>
+        </ButtonRow>
+      </PageContent>
+    )
+  }
+
+  return (
+    <PageContent onBack={routes.SOL_SEND}>
+      <ModalHeading>Confirm transfer</ModalHeading>
+      <ModalBody>Review the transaction details before sending.</ModalBody>
+
+      <SummaryList>
+        <SummaryItem>
+          <SummaryLabel>Sending</SummaryLabel>
+          <AmountValue>{amount || '0'} SOL</AmountValue>
+        </SummaryItem>
+        <SummaryItem>
+          <SummaryLabel>From</SummaryLabel>
+          <AddressValue>
+            {address ? (
+              <CopyText size="1rem" value={address}>
+                {truncateSolanaAddress(address)}
+              </CopyText>
+            ) : (
+              '--'
+            )}
+          </AddressValue>
+        </SummaryItem>
+        <SummaryItem>
+          <SummaryLabel>To</SummaryLabel>
+          <AddressValue>
+            {recipient ? (
+              <CopyText size="1rem" value={recipient}>
+                {truncateSolanaAddress(recipient)}
+              </CopyText>
+            ) : (
+              '--'
+            )}
+          </AddressValue>
+        </SummaryItem>
+      </SummaryList>
+
+      <GaslessRow>
+        <div>
+          <SummaryLabel>Sponsor network fee</SummaryLabel>
+          <div style={{ fontSize: 12, color: 'var(--ck-body-color-muted)', marginTop: 2 }}>
+            Pay no SOL fee (requires a sponsorship policy)
+          </div>
+        </div>
+        <GaslessToggle
+          type="button"
+          role="switch"
+          aria-checked={gasless}
+          aria-label="Sponsor network fee"
+          $on={gasless}
+          onClick={() => setGasless((v) => !v)}
+          disabled={isLoading}
+        >
+          <span />
+        </GaslessToggle>
+      </GaslessRow>
+
+      {error && (
+        <ErrorContainer>
+          <ErrorTitle>Transaction failed</ErrorTitle>
+          <ErrorMessage>{error}</ErrorMessage>
+        </ErrorContainer>
+      )}
+
+      <ButtonRow>
+        <Button variant="primary" onClick={handleConfirm} disabled={!address || isLoading} waiting={isLoading}>
+          {isLoading ? 'Confirming...' : 'Confirm'}
+        </Button>
+        <Button variant="secondary" onClick={() => setRoute(routes.SOL_SEND)} disabled={isLoading}>
+          Cancel
+        </Button>
+      </ButtonRow>
+    </PageContent>
+  )
+}

--- a/packages/openfort-react/src/components/Pages/SendConfirmation/styles.ts
+++ b/packages/openfort-react/src/components/Pages/SendConfirmation/styles.ts
@@ -140,3 +140,43 @@ export const ErrorAction = styled.div`
   color: var(--ck-body-color-muted);
   line-height: 1.4;
 `
+
+export const GaslessRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 4px 0 8px;
+  text-align: left;
+`
+
+/** A minimal theme-aware switch for the Solana "sponsor fee" toggle. */
+export const GaslessToggle = styled.button<{ $on?: boolean }>`
+  position: relative;
+  flex-shrink: 0;
+  width: 40px;
+  height: 24px;
+  border-radius: 999px;
+  border: 1px solid var(--ck-body-divider);
+  background: ${(props) => (props.$on ? 'var(--ck-body-color-valid, #22c55e)' : 'var(--ck-body-background-secondary)')};
+  cursor: pointer;
+  transition: background 150ms ease;
+  padding: 0;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  > span {
+    position: absolute;
+    top: 50%;
+    left: ${(props) => (props.$on ? '18px' : '2px')};
+    transform: translateY(-50%);
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #fff;
+    transition: left 150ms ease;
+  }
+`

--- a/packages/openfort-react/src/solana/transfer.ts
+++ b/packages/openfort-react/src/solana/transfer.ts
@@ -1,0 +1,209 @@
+'use client'
+
+/**
+ * Solana SOL transfer helpers.
+ *
+ * Builds, signs, and broadcasts a native SOL transfer with `@solana/kit`, signing
+ * the message bytes through the embedded wallet provider (Ed25519). Mirrors the
+ * documented `createOpenfortSigner` pattern. `@solana/kit`, `@solana-program/system`,
+ * and `@solana/kora` are loaded lazily so the EVM bundle and the kit `^2 || ^5`
+ * range stay untouched — only a Solana send pulls them in at runtime.
+ */
+
+import type { Address, SignatureBytes, SignatureDictionary, TransactionSigner } from '@solana/kit'
+import type { OpenfortEmbeddedSolanaWalletProvider, SolanaCluster } from './types'
+
+/** The System program id — the "token" for a native SOL transfer through Kora. */
+const SYSTEM_PROGRAM_ID = '11111111111111111111111111111111'
+const SEND_TIMEOUT_MS = 60_000
+
+/** Decimal SOL → lamports, without floating-point loss. */
+export function solToLamports(amountSol: number): bigint {
+  const [whole, frac = ''] = amountSol.toString().split('.')
+  const padded = (frac + '0'.repeat(9)).slice(0, 9)
+  return BigInt(`${whole || '0'}${padded}`)
+}
+
+/** Ed25519 signatures are 64 bytes; trim a trailing recovery byte if one is present. */
+function toEd25519Signature(raw: Uint8Array): SignatureBytes {
+  const trimmed = raw.length === 65 ? raw.slice(0, 64) : raw
+  if (trimmed.length !== 64) {
+    throw new Error(`Invalid Ed25519 signature: expected 64 bytes, got ${trimmed.length}`)
+  }
+  return trimmed as SignatureBytes
+}
+
+/** Solana confirmation needs a wss endpoint; public cluster RPCs serve one at the same host. */
+function deriveWssUrl(rpcUrl: string): string {
+  return rpcUrl.replace(/^https?:\/\//, 'wss://')
+}
+
+export type SendSolParams = {
+  from: string
+  to: string
+  amountSol: number
+  provider: OpenfortEmbeddedSolanaWalletProvider
+  rpcUrl: string
+  commitment?: 'processed' | 'confirmed' | 'finalized'
+}
+
+/**
+ * Build, sign, and broadcast a native SOL transfer. Returns the transaction
+ * signature (base58). The wallet pays the network fee — use {@link sendSolGasless}
+ * to sponsor it.
+ */
+export async function sendSol({
+  from,
+  to,
+  amountSol,
+  provider,
+  rpcUrl,
+  commitment = 'confirmed',
+}: SendSolParams): Promise<string> {
+  const kit = await import('@solana/kit')
+  const { getTransferSolInstruction } = await import('@solana-program/system')
+
+  const fromAddress = kit.address(from)
+  const rpc = kit.createSolanaRpc(rpcUrl)
+  const rpcSubscriptions = kit.createSolanaRpcSubscriptions(deriveWssUrl(rpcUrl))
+
+  const signer: TransactionSigner = {
+    address: fromAddress,
+    signTransactions: async (transactions): Promise<readonly SignatureDictionary[]> =>
+      Promise.all(
+        transactions.map(async (transaction) => {
+          const { signature } = await provider.signTransaction({
+            messageBytes: new Uint8Array(transaction.messageBytes),
+          })
+          const bytes = toEd25519Signature(new Uint8Array(kit.getBase58Encoder().encode(signature)))
+          return Object.freeze({ [fromAddress]: bytes })
+        })
+      ),
+  }
+
+  const { value: latestBlockhash } = await rpc.getLatestBlockhash().send()
+
+  const message = kit.pipe(
+    kit.createTransactionMessage({ version: 0 }),
+    (tx) => kit.setTransactionMessageFeePayer(fromAddress, tx),
+    (tx) => kit.setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+    (tx) =>
+      kit.appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: signer,
+          destination: kit.address(to),
+          amount: kit.lamports(solToLamports(amountSol)),
+        }),
+        tx
+      )
+  )
+
+  const signedTransaction = await kit.signTransactionMessageWithSigners(message)
+
+  const sendAndConfirm = kit.sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })
+  const abortController = new AbortController()
+  const timeout = setTimeout(() => abortController.abort(), SEND_TIMEOUT_MS)
+  try {
+    await sendAndConfirm(signedTransaction as Parameters<typeof sendAndConfirm>[0], {
+      commitment,
+      abortSignal: abortController.signal,
+    })
+  } finally {
+    clearTimeout(timeout)
+  }
+
+  return kit.getSignatureFromTransaction(signedTransaction)
+}
+
+export type SendSolGaslessParams = {
+  from: string
+  to: string
+  amountSol: number
+  provider: OpenfortEmbeddedSolanaWalletProvider
+  cluster: SolanaCluster
+  /** Project publishable key; sent to the Openfort Solana paymaster (Kora) as a Bearer token. */
+  publishableKey: string
+}
+
+/** The Openfort Solana paymaster (Kora) endpoint for a cluster. */
+function koraRpcUrl(cluster: SolanaCluster): string {
+  const segment = cluster === 'mainnet-beta' ? 'mainnet' : cluster
+  return `https://api.openfort.io/rpc/solana/${segment}`
+}
+
+/**
+ * Send a native SOL transfer with fees sponsored by the Openfort Solana paymaster
+ * (Kora): Kora is the fee payer, the user signs their part with the embedded wallet,
+ * and Kora co-signs + broadcasts. Requires a `sponsorSolTransaction` policy on the
+ * project. Returns the transaction signature (base58).
+ */
+export async function sendSolGasless({
+  from,
+  to,
+  amountSol,
+  provider,
+  cluster,
+  publishableKey,
+}: SendSolGaslessParams): Promise<string> {
+  const kit = await import('@solana/kit')
+  const { KoraClient } = await import('@solana/kora')
+
+  const client = new KoraClient({ rpcUrl: koraRpcUrl(cluster), apiKey: `Bearer ${publishableKey}` })
+
+  // 1. Kora's fee-payer signer.
+  const { signer_address } = await client.getPayerSigner()
+  const feePayer = kit.createNoopSigner(signer_address as Address)
+
+  // 2. A sponsored native SOL transfer, with Kora as the fee payer.
+  const { instructions } = await client.transferTransaction({
+    amount: Number(solToLamports(amountSol)),
+    token: SYSTEM_PROGRAM_ID,
+    source: from,
+    destination: to,
+    signer_key: signer_address,
+  })
+
+  // 3. Build the message with Kora as fee payer.
+  const { blockhash } = await client.getBlockhash()
+  const message = kit.pipe(
+    kit.createTransactionMessage({ version: 0 }),
+    (tx) => kit.setTransactionMessageFeePayerSigner(feePayer, tx),
+    (tx) =>
+      kit.setTransactionMessageLifetimeUsingBlockhash(
+        {
+          blockhash: blockhash as Parameters<typeof kit.setTransactionMessageLifetimeUsingBlockhash>[0]['blockhash'],
+          lastValidBlockHeight: BigInt(0),
+        },
+        tx
+      ),
+    (tx) => kit.appendTransactionMessageInstructions(instructions, tx)
+  )
+
+  // 4. Inject the user's Ed25519 signature alongside Kora's placeholder.
+  const partiallySigned = await kit.partiallySignTransactionMessageWithSigners(message)
+  const { signature } = await provider.signTransaction(new Uint8Array(partiallySigned.messageBytes))
+  const userSigned = {
+    ...partiallySigned,
+    signatures: {
+      ...partiallySigned.signatures,
+      [from]: toEd25519Signature(new Uint8Array(kit.getBase58Encoder().encode(signature))),
+    },
+  }
+  const wire = kit.getBase64EncodedWireTransaction(userSigned)
+
+  // 5. Kora co-signs (as fee payer) and broadcasts.
+  const response = (await client.signAndSendTransaction({
+    transaction: wire,
+    signer_key: signer_address,
+  })) as unknown as Record<string, unknown>
+
+  const direct = response.signature as string | undefined
+  if (direct) return direct
+  const signedTxB64 = response.signed_transaction as string | undefined
+  if (signedTxB64) {
+    // Wire format: [sigCount(1)][signature(64)]... — the first signature is the tx id.
+    const wireBytes = Uint8Array.from(atob(signedTxB64), (c) => c.charCodeAt(0))
+    return kit.getBase58Decoder().decode(wireBytes.slice(1, 65))
+  }
+  throw new Error('Failed to extract transaction signature from the Kora response')
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -866,9 +866,15 @@ importers:
       '@openfort/openfort-js':
         specifier: ^1.3.9
         version: 1.3.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@solana-program/system':
+        specifier: ^0.10.0
+        version: 0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/kit':
         specifier: ^2.0.0 || ^5.0.0
         version: 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/kora':
+        specifier: ^0.1.1
+        version: 0.1.3(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)))(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
       buffer:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
Adds a **Send** action to the Solana wallet modal, mirroring EVM's Send. Closes the parity gap noted in the deposit-hub work: Solana had only Deposit, no Send.

> **Stacked on #272** (the Solana deposit-hub parity). Base is `funding/deposit-hub-reapply` so the diff is just the Send feature; GitHub auto-retargets to `main` once #272 merges.

## What's in it
- **`solana/transfer.ts`** — `sendSol` (plain) and `sendSolGasless` (Openfort Solana paymaster / Kora). Built with `@solana/kit`, signing the message bytes through the embedded provider (Ed25519). Both are **lazy-loaded** so EVM-only bundles and the `@solana/kit ^2 || ^5` peer range are untouched.
- **`SolanaSend`** form — native SOL (amount + recipient, Max, base58 + balance validation).
- **`SolanaSendConfirmation`** — review, a **gasless** toggle (sponsor the fee via Kora), and the signature + explorer link on success.
- Dedicated `sol:send` / `sol:sendConfirmation` routes + a **Send** button on `SolanaConnected`.
- `@solana-program/system` + `@solana/kora` added as **optional peer deps** (matching `@solana/kit`).

Follows the documented [Send transaction (Solana)](https://openfort.io/docs/products/embedded-wallet/react/wallet/actions/send-transaction/solana) pattern.

## Scope
- **Native SOL only** this PR; SPL tokens (USDC) are a follow-up (needs a Solana token-asset source).
- Gasless requires a `sponsorSolTransaction` policy on the project.

## Verify
`pnpm build` ✅ · `biome` clean · `vitest` → 197 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)