### PR TITLE
fix(funding): always settle deposits into the active wallet

### DIFF
--- a/packages/openfort-react/src/__tests__/useFundingTarget.test.ts
+++ b/packages/openfort-react/src/__tests__/useFundingTarget.test.ts
@@ -5,7 +5,7 @@ import { DEST_CHAIN, DEST_CHAIN_SOL, DEST_USDC, DEST_USDC_SOL } from '../compone
 
 // useFundingTarget reads uiConfig.funding from useOpenfort and chainType from
 // useOpenfortCore. Stub both so we can drive the chain-aware default selection.
-const mockUiConfig: { funding?: { targetChain?: string; targetCurrency?: string; targetAddress?: string } } = {}
+const mockUiConfig: { funding?: { targetChain?: string; targetCurrency?: string } } = {}
 let mockChainType: ChainTypeEnum = ChainTypeEnum.EVM
 
 vi.mock('../components/Openfort/useOpenfort', () => ({
@@ -25,23 +25,23 @@ describe('useFundingTarget', () => {
 
   it('defaults to USDC on Base for EVM wallets', () => {
     const { result } = renderHook(() => useFundingTarget())
-    expect(result.current).toEqual({ chain: DEST_CHAIN, currency: DEST_USDC, address: undefined })
+    expect(result.current).toEqual({ chain: DEST_CHAIN, currency: DEST_USDC })
   })
 
   it('defaults to USDC on Solana mainnet for SVM wallets', () => {
     mockChainType = ChainTypeEnum.SVM
     const { result } = renderHook(() => useFundingTarget())
-    expect(result.current).toEqual({ chain: DEST_CHAIN_SOL, currency: DEST_USDC_SOL, address: undefined })
+    expect(result.current).toEqual({ chain: DEST_CHAIN_SOL, currency: DEST_USDC_SOL })
   })
 
-  it('honors integrator overrides regardless of chain type', () => {
-    mockUiConfig.funding = { targetChain: 'eip155:1', targetCurrency: '0xabc', targetAddress: '0xdest' }
+  it('honors integrator chain/currency overrides regardless of chain type', () => {
+    mockUiConfig.funding = { targetChain: 'eip155:1', targetCurrency: '0xabc' }
 
     const evm = renderHook(() => useFundingTarget())
-    expect(evm.result.current).toEqual({ chain: 'eip155:1', currency: '0xabc', address: '0xdest' })
+    expect(evm.result.current).toEqual({ chain: 'eip155:1', currency: '0xabc' })
 
     mockChainType = ChainTypeEnum.SVM
     const svm = renderHook(() => useFundingTarget())
-    expect(svm.result.current).toEqual({ chain: 'eip155:1', currency: '0xabc', address: '0xdest' })
+    expect(svm.result.current).toEqual({ chain: 'eip155:1', currency: '0xabc' })
   })
 })

--- a/packages/openfort-react/src/components/Openfort/types.ts
+++ b/packages/openfort-react/src/components/Openfort/types.ts
@@ -409,15 +409,6 @@ export type FundingUIOptions = {
    */
   targetCurrency?: string
   /**
-   * Destination wallet that receives the deposit. Overrides the active embedded
-   * wallet address — set this when funds should land somewhere other than the
-   * active address (e.g. a deployed smart account when the active address is its
-   * owner EOA). Must be a valid address on `targetChain`; for EVM it also receives
-   * cross-chain refunds on the source chain, so use an address valid across chains.
-   * @default the active embedded wallet address
-   */
-  targetAddress?: string
-  /**
    * Which funding methods the Deposit hub shows, and in what order. Omit to show
    * all available methods (Apple Pay first on mobile). Mirrors `authProviders`.
    * @example [FundingMethod.WALLET, FundingMethod.ADDRESS]

--- a/packages/openfort-react/src/components/Pages/Deposit/useDepositRoute.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/useDepositRoute.ts
@@ -48,9 +48,8 @@ export function useDepositRoute(kind: DepositRouteKind) {
   // The CEX rail rides Coinbase Onramp, which only delivers to a fixed set of EVM
   // chains — offer those as the pay-with sources.
   const chains: FundingChain[] = kind === 'cex' ? sourceChains.filter((c) => isCexDeliverable(c.id)) : sourceChains
-  // Where funds land: the integrator's override, else the active embedded wallet.
-  const walletAddress = wallet.status === 'connected' ? wallet.address : undefined
-  const address = target.address ?? walletAddress
+  // Where funds land: the active embedded wallet (the Relay deposit recipient).
+  const address = wallet.status === 'connected' ? wallet.address : undefined
 
   const [chainId, setChainId] = useState('')
   const [currencySymbol, setCurrencySymbol] = useState('')

--- a/packages/openfort-react/src/components/Pages/Deposit/useFundingTarget.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/useFundingTarget.ts
@@ -6,19 +6,18 @@ import { useOpenfort } from '../../Openfort/useOpenfort'
 import { DEST_CHAIN, DEST_CHAIN_SOL, DEST_USDC, DEST_USDC_SOL } from './sources'
 
 /**
- * The destination route Deposit-hub funding settles into. Integrators override
- * it via `uiConfig.funding.{targetChain,targetCurrency,targetAddress}`; chain and
- * currency default to USDC on the active chain type (Base for EVM, Solana mainnet
- * for SVM) so the flow works with zero configuration. `address` is undefined unless
- * overridden — callers fall back to the active embedded wallet.
+ * The destination route Deposit-hub funding settles into. Integrators override the
+ * chain and currency via `uiConfig.funding.{targetChain,targetCurrency}`; both
+ * default to USDC on the active chain type (Base for EVM, Solana mainnet for SVM)
+ * so the flow works with zero configuration. The deposit recipient is always the
+ * active embedded wallet — callers resolve it.
  */
-export function useFundingTarget(): { chain: string; currency: string; address?: string } {
+export function useFundingTarget(): { chain: string; currency: string } {
   const { uiConfig } = useOpenfort()
   const { chainType } = useOpenfortCore()
   const isSolana = chainType === ChainTypeEnum.SVM
   return {
     chain: uiConfig.funding?.targetChain ?? (isSolana ? DEST_CHAIN_SOL : DEST_CHAIN),
     currency: uiConfig.funding?.targetCurrency ?? (isSolana ? DEST_USDC_SOL : DEST_USDC),
-    address: uiConfig.funding?.targetAddress,
   }
 }


### PR DESCRIPTION
## What

Removes the `uiConfig.funding.targetAddress` override. Deposits always settle into the user's **active embedded wallet** (the EOA / smart account the SDK already resolves) — that address is exactly what's sent to Relay as the deposit recipient, so a manual override isn't needed.

- `useFundingTarget` → returns `{ chain, currency }` (no `address`).
- `useDepositRoute` → uses the active embedded wallet address as the Relay recipient.
- Dropped `targetAddress` from `FundingUIOptions` and its test cases.

The Relay target address is **preserved** — it's just always the active wallet now, not overridable.

## Base

Targets `funding/deposit-hub-reapply` (PR #272), where the funding code lives. Docs already match (documentation#400, merged — the "Overriding the destination address" section was removed).

## Verify

- `useFundingTarget` test: 3/3 pass.
- biome clean; no first-party tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)