### PR TITLE
feat(solana): network indicator in the Connected modal

### DIFF
--- a/.changeset/solana-network-indicator.md
+++ b/.changeset/solana-network-indicator.md
@@ -1,0 +1,5 @@
+---
+'@openfort/react': patch
+---
+
+Show a Solana network indicator in the Connected modal, mirroring the EVM chain badge. The cluster is fixed by `walletConfig.solana` and the indicator is read-only — switching between Solana and EVM is not offered.

--- a/packages/openfort-react/src/assets/logos.tsx
+++ b/packages/openfort-react/src/assets/logos.tsx
@@ -640,6 +640,37 @@ const Phantom = ({ background = false, ...props }) => (
   </svg>
 );
 
+const Solana = ({ ...props }) => (
+  <svg {...props} viewBox="0 0 398 312" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <title>Solana</title>
+    <defs>
+      <linearGradient
+        id="openfort-solana-gradient"
+        x1="360.879"
+        y1="-37.455"
+        x2="141.213"
+        y2="383.294"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#00FFA3" />
+        <stop offset="1" stopColor="#DC1FFF" />
+      </linearGradient>
+    </defs>
+    <path
+      fill="url(#openfort-solana-gradient)"
+      d="M64.6 237.9c2.4-2.4 5.7-3.8 9.2-3.8h317.4c5.8 0 8.7 7 4.6 11.1l-62.7 62.7c-2.4 2.4-5.7 3.8-9.2 3.8H15.5c-5.8 0-8.7-7-4.6-11.1L64.6 237.9z"
+    />
+    <path
+      fill="url(#openfort-solana-gradient)"
+      d="M64.6 3.8C67.1 1.4 70.4 0 73.8 0h317.4c5.8 0 8.7 7 4.6 11.1l-62.7 62.7c-2.4 2.4-5.7 3.8-9.2 3.8H15.5c-5.8 0-8.7-7-4.6-11.1L64.6 3.8z"
+    />
+    <path
+      fill="url(#openfort-solana-gradient)"
+      d="M333.1 120.1c-2.4-2.4-5.7-3.8-9.2-3.8H6.5c-5.8 0-8.7 7-4.6 11.1l62.7 62.7c2.4 2.4 5.7 3.8 9.2 3.8h317.4c5.8 0 8.7-7 4.6-11.1L333.1 120.1z"
+    />
+  </svg>
+);
+
 const PlaceHolder = () => {
   return <div style={{ width: 80, height: 80, background: '#555' }}></div>;
 };
@@ -1363,6 +1394,7 @@ export default {
   Frontier,
   Zerion,
   Phantom,
+  Solana,
   PlaceHolder,
   Frame,
   Dawn,

--- a/packages/openfort-react/src/components/Common/SolanaChain/index.tsx
+++ b/packages/openfort-react/src/components/Common/SolanaChain/index.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import Logos from '../../../assets/logos'
+import { useSolanaContext } from '../../../solana/SolanaContext'
+import styled from '../../../styles/styled'
+import Tooltip from '../Tooltip'
+
+/** `mainnet-beta` → "Mainnet"; otherwise capitalize the cluster name. */
+function formatCluster(cluster?: string): string {
+  if (!cluster) return ''
+  if (cluster === 'mainnet-beta') return 'Mainnet'
+  return cluster.charAt(0).toUpperCase() + cluster.slice(1)
+}
+
+const Badge = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #131313;
+  border: 2px solid var(--ck-body-background, #fff);
+  box-sizing: border-box;
+`
+
+/**
+ * Read-only Solana network indicator for the Connected modal — the Solana logo,
+ * with the active cluster shown on hover. There is no switch: the cluster is
+ * fixed by `walletConfig.solana`, and switching between Solana and EVM is
+ * intentionally unsupported.
+ */
+const SolanaChain = () => {
+  const cluster = useSolanaContext()?.cluster
+  const label = cluster ? `Solana · ${formatCluster(cluster)}` : 'Solana'
+
+  return (
+    <Tooltip message={label}>
+      <Badge aria-label={label}>
+        <Logos.Solana style={{ width: '62%', height: 'auto' }} />
+      </Badge>
+    </Tooltip>
+  )
+}
+
+export default SolanaChain

--- a/packages/openfort-react/src/components/Pages/Connected/SolanaConnected.tsx
+++ b/packages/openfort-react/src/components/Pages/Connected/SolanaConnected.tsx
@@ -24,12 +24,13 @@ import Avatar from '../../Common/Avatar'
 import Button from '../../Common/Button'
 import { TextLinkButton } from '../../Common/Button/styles'
 import { CopyText } from '../../Common/CopyToClipboard/CopyText'
+import SolanaChain from '../../Common/SolanaChain'
 import { useThemeContext } from '../../ConnectKitThemeProvider/ConnectKitThemeProvider'
 import { routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
 import { ConnectedPageLayout } from './ConnectedPageLayout'
-import { ActionButton, Balance, LinkedProvidersToggle } from './styles'
+import { ActionButton, Balance, ChainSelectorContainer, LinkedProvidersToggle } from './styles'
 
 const SolanaConnected: React.FC = () => {
   const context = useOpenfort()
@@ -133,6 +134,11 @@ const SolanaConnected: React.FC = () => {
         address={address ?? ''}
         displayName={<CopyText value={address ?? ''}>{truncateSolanaAddress(address ?? '', separator)}</CopyText>}
         avatar={avatar}
+        beforeAvatar={
+          <ChainSelectorContainer initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
+            <SolanaChain />
+          </ChainSelectorContainer>
+        }
         balance={balanceNode}
         actions={
           <>


### PR DESCRIPTION
EVM shows the active chain's logo in the wallet-modal header (clickable to switch chains). The **Solana** Connected screen had no network indicator — no visual clue you're on Solana. This adds a Solana network badge in the same `beforeAvatar` slot EVM uses.

- **`assets/logos`** — adds the Solana network mark (only the Phantom wallet logo existed).
- **`Common/SolanaChain`** — a read-only badge: the Solana logo, with the active cluster on hover (`Solana · Devnet`).
- **`SolanaConnected`** — passes `beforeAvatar`, matching `EthereumConnected`'s structure.

## No switching (by design)
Per the request, this **does not** switch chains. The Solana cluster is fixed by `walletConfig.solana`, and switching between Solana and EVM is intentionally unsupported — so it's a pure indicator. (Runtime cluster switching would need new `SolanaContext` infra; out of scope.)

## Verify
`pnpm build` ✅ · `biome` clean · `vitest` → 197 passing. Dogfooded in the playground (Solana mode): the badge renders at the bottom-right of the avatar, exactly where EVM's chain logo sits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)