### PR TITLE
fix(send): tolerate bigint query keys to stop native-send white screen

### DIFF
--- a/.changeset/fix-send-bigint-querykey.md
+++ b/.changeset/fix-send-bigint-querykey.md
@@ -1,0 +1,5 @@
+---
+'@openfort/react': patch
+---
+
+Fix white screen when sending a native token (e.g. ETH) from the wallet balance. The gas-estimate query keyed on the bigint send amount, and `useAsyncData` serialized its key with `JSON.stringify`, which throws on a BigInt and crashed the confirm modal. Query keys are now serialized bigint-safely.

--- a/packages/openfort-react/src/__tests__/hooks/useAsyncData.test.tsx
+++ b/packages/openfort-react/src/__tests__/hooks/useAsyncData.test.tsx
@@ -1,0 +1,37 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * A native ETH send keys its gas estimate on the bigint amount
+ * (`['gas-estimate', account, to, value, ...]`). `JSON.stringify` throws on a
+ * BigInt, which used to crash the whole confirm modal to a white screen. The
+ * hook must serialize bigint keys instead of throwing.
+ */
+import { invalidateAsyncData, useAsyncData } from '../../shared/hooks/useAsyncData'
+
+describe('useAsyncData bigint queryKey', () => {
+  beforeEach(() => {
+    invalidateAsyncData()
+  })
+
+  it('does not throw when the queryKey contains a bigint', async () => {
+    const queryFn = vi.fn().mockResolvedValue('ok')
+
+    const { result } = renderHook(() => useAsyncData({ queryKey: ['gas-estimate', 100000000000000000n], queryFn }))
+
+    await waitFor(() => expect(result.current.data).toBe('ok'))
+    expect(queryFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats distinct bigint keys as distinct cache entries', async () => {
+    const queryFn = vi.fn().mockImplementation((amount: bigint) => Promise.resolve(amount.toString()))
+
+    const first = renderHook(() => useAsyncData({ queryKey: ['amount', 1n], queryFn: () => queryFn(1n) }))
+    await waitFor(() => expect(first.result.current.data).toBe('1'))
+
+    const second = renderHook(() => useAsyncData({ queryKey: ['amount', 2n], queryFn: () => queryFn(2n) }))
+    await waitFor(() => expect(second.result.current.data).toBe('2'))
+
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/openfort-react/src/shared/hooks/useAsyncData.ts
+++ b/packages/openfort-react/src/shared/hooks/useAsyncData.ts
@@ -16,6 +16,20 @@ type CacheEntry = { data: unknown; timestamp: number }
 const dataCache = new Map<string, CacheEntry>()
 
 /**
+ * Serialize a queryKey to a stable cache string.
+ *
+ * `JSON.stringify` throws `TypeError: Do not know how to serialize a BigInt`,
+ * and queryKeys legitimately carry bigints (token amounts, balances, gas
+ * values — e.g. a native ETH send keys its gas estimate on the bigint amount).
+ * Without this replacer such a key crashes the whole modal render. A bigint is
+ * encoded as its decimal digits with an `n` suffix so distinct values stay
+ * distinct keys.
+ */
+function serializeQueryKey(queryKey: readonly unknown[]): string {
+  return JSON.stringify(queryKey, (_key, value) => (typeof value === 'bigint' ? `${value}n` : value))
+}
+
+/**
  * Drop cached entries so the next mount (or refetch) hits the network instead of
  * painting stale data. Pass a substring matched against the serialized queryKey
  * to target specific queries (e.g. `'walletAssets'`), or omit to clear everything.
@@ -64,8 +78,8 @@ export function useAsyncData<T>({
   refetch: () => Promise<T | undefined>
 } {
   // Serialize queryKey to a stable string so the effect only re-runs when values change,
-  // not when array/object references change.
-  const queryKeyStr = JSON.stringify(queryKey)
+  // not when array/object references change. Bigint-safe (see serializeQueryKey).
+  const queryKeyStr = serializeQueryKey(queryKey)
 
   const [data, setData] = useState<T | undefined>(() => dataCache.get(queryKeyStr)?.data as T | undefined)
   const [error, setError] = useState<Error | null>(null)


### PR DESCRIPTION
## Problem

Sending a **native** token (e.g. ETH) from the wallet balance crashed the confirm modal to a **white screen**:

```
TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
```

ERC-20 sends were unaffected, which pointed straight at what differs between the two paths.

## Root cause

`EstimatedFees` keys its gas-estimate query on the send amount:

```ts
queryKey: ['gas-estimate', account, to, value, data, chainId]
```

- **Native send** → `value` is the parsed amount as a `bigint`.
- **ERC-20 send** → `value` is `undefined` (the amount is encoded into the hex `data` string instead).

`useAsyncData` serializes the key with `JSON.stringify(queryKey)` on every render. `JSON.stringify` throws on a `BigInt`, so the native path took down the whole modal render — hence the white screen. ERC-20, having no bigint in its key, was fine.

## Fix

Serialize query keys **bigint-safely** inside `useAsyncData` (encode bigints as their decimal digits with an `n` suffix). Fixing the generic hook protects every present and future caller, not just `EstimatedFees`.

## Tests

- New `useAsyncData` regression test: a bigint in the query key no longer throws, and distinct bigints stay distinct cache entries. It reproduces the exact `Do not know how to serialize a BigInt` error when the fix is reverted.
- The existing `SendConfirmation` test stubbed out `EstimatedFees`, which is why it never caught this.
- Full unit suite: 199 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)