### PR TITLE
feat(solana): card-buy (fiat onramp) support for Solana wallets

### DIFF
--- a/.changeset/solana-card-buy.md
+++ b/.changeset/solana-card-buy.md
@@ -1,0 +1,5 @@
+---
+'@openfort/react': patch
+---
+
+Adapt the Add funds → Card (fiat onramp) flow for Solana wallets: buy USDC (default) or SOL, resolve the onramp `destinationNetwork` to `solana`, seed the Solana card-buy with USDC, and link the Solana explorer on completion. EVM card-buy is unchanged.

--- a/packages/openfort-react/src/__tests__/resolveOnrampNetwork.test.ts
+++ b/packages/openfort-react/src/__tests__/resolveOnrampNetwork.test.ts
@@ -1,0 +1,24 @@
+import { ChainTypeEnum } from '@openfort/openfort-js'
+import { describe, expect, it } from 'vitest'
+import { resolveOnrampNetwork } from '../components/Pages/Buy/onrampApi'
+
+describe('resolveOnrampNetwork', () => {
+  it('resolves Solana wallets to the solana network (ignoring any chainId)', () => {
+    expect(resolveOnrampNetwork(ChainTypeEnum.SVM)).toBe('solana')
+    expect(resolveOnrampNetwork(ChainTypeEnum.SVM, 8453)).toBe('solana')
+  })
+
+  it('maps EVM chain ids to onramp network names', () => {
+    expect(resolveOnrampNetwork(ChainTypeEnum.EVM, 1)).toBe('ethereum')
+    expect(resolveOnrampNetwork(ChainTypeEnum.EVM, 8453)).toBe('base')
+    expect(resolveOnrampNetwork(ChainTypeEnum.EVM, 137)).toBe('polygon')
+  })
+
+  it('falls back to base for an unmapped EVM chain id', () => {
+    expect(resolveOnrampNetwork(ChainTypeEnum.EVM, 999999)).toBe('base')
+  })
+
+  it('returns undefined for an EVM wallet whose chain id is not ready yet', () => {
+    expect(resolveOnrampNetwork(ChainTypeEnum.EVM)).toBeUndefined()
+  })
+})

--- a/packages/openfort-react/src/components/Pages/Buy/coinbaseApi.ts
+++ b/packages/openfort-react/src/components/Pages/Buy/coinbaseApi.ts
@@ -40,18 +40,6 @@ type CreateCoinbaseSessionParams = {
   clientIp?: string
 }
 
-// Map chain IDs to Coinbase network names
-const getNetworkName = (chainId: number): string => {
-  const networkMap: Record<number, string> = {
-    1: 'ethereum',
-    8453: 'base',
-    137: 'polygon',
-    42161: 'arbitrum',
-    10: 'optimism',
-  }
-  return networkMap[chainId] || 'base'
-}
-
 // Coinbase supported currencies (more extensive than Stripe)
 const COINBASE_SUPPORTED_CURRENCIES = [
   'btc',
@@ -106,11 +94,11 @@ const getCurrencyCode = (token: Asset): string => {
 export const createCoinbaseSession = async (
   params: Omit<CreateCoinbaseSessionParams, 'destinationCurrency' | 'destinationNetwork'> & {
     token: Asset
-    chainId: number
+    network: string
     publishableKey: string
   }
 ): Promise<CoinbaseOnrampResponse> => {
-  const { token, chainId, publishableKey, ...rest } = params
+  const { token, network, publishableKey, ...rest } = params
 
   if (!publishableKey) {
     throw new Error('Publishable key is required for authentication')
@@ -120,7 +108,7 @@ export const createCoinbaseSession = async (
   const requestBody: CreateCoinbaseSessionParams & { provider: string } = {
     provider: 'coinbase',
     destinationCurrency: getCurrencyCode(token),
-    destinationNetwork: getNetworkName(chainId),
+    destinationNetwork: network,
     destinationAddress: rest.destinationAddress,
   }
 
@@ -167,11 +155,11 @@ type GetCoinbaseQuoteParams = {
 const _getCoinbaseQuote = async (
   params: Omit<GetCoinbaseQuoteParams, 'destinationCurrency' | 'destinationNetwork'> & {
     token: Asset
-    chainId: number
+    network: string
     publishableKey: string
   }
 ): Promise<CoinbaseQuoteResponse> => {
-  const { token, chainId, publishableKey, ...rest } = params
+  const { token, network, publishableKey, ...rest } = params
 
   if (!publishableKey) {
     throw new Error('Publishable key is required for authentication')
@@ -181,7 +169,7 @@ const _getCoinbaseQuote = async (
   const requestBody: GetCoinbaseQuoteParams & { provider: string } = {
     provider: 'coinbase',
     destinationCurrency: getCurrencyCode(token),
-    destinationNetwork: getNetworkName(chainId),
+    destinationNetwork: network,
     sourceCurrency: rest.sourceCurrency,
     sourceAmount: rest.sourceAmount,
     paymentMethod: rest.paymentMethod,

--- a/packages/openfort-react/src/components/Pages/Buy/index.tsx
+++ b/packages/openfort-react/src/components/Pages/Buy/index.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import { ChainTypeEnum } from '@openfort/openfort-js'
 import { useEffect, useMemo, useState } from 'react'
 import { useEthereumWalletAssets } from '../../../ethereum/hooks/useEthereumWalletAssets'
 import useLocales from '../../../hooks/useLocales'
+import { useOpenfortCore } from '../../../openfort/useOpenfort'
 import Button from '../../Common/Button'
 import { Arrow, ArrowChevron } from '../../Common/Button/styles'
 import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
@@ -10,6 +12,7 @@ import { routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
 import { getAssetSymbol, isSameToken, sanitizeAmountInput, sanitizeForParsing } from '../Send/utils'
+import { SOLANA_BUY_CURRENCIES } from './solanaCurrencies'
 import {
   AmountCard,
   AmountInput,
@@ -32,7 +35,11 @@ const amountPresets = [10, 20, 50]
 const Buy = () => {
   const { buyForm, setBuyForm, setRoute, triggerResize } = useOpenfort()
   const locales = useLocales()
-  const { data: assets } = useEthereumWalletAssets()
+  const { chainType } = useOpenfortCore()
+  const { data: ethAssets } = useEthereumWalletAssets()
+  // Solana wallets buy Solana currencies (USDC default, then SOL); EVM reads its
+  // own assets. Both hooks run unconditionally; the active chain picks the list.
+  const assets = chainType === ChainTypeEnum.SVM ? SOLANA_BUY_CURRENCIES : ethAssets
 
   const [pressedPreset, setPressedPreset] = useState<number | null>(null)
 

--- a/packages/openfort-react/src/components/Pages/Buy/onrampApi.ts
+++ b/packages/openfort-react/src/components/Pages/Buy/onrampApi.ts
@@ -1,4 +1,4 @@
-import { SDKConfiguration } from '@openfort/openfort-js'
+import { ChainTypeEnum, SDKConfiguration } from '@openfort/openfort-js'
 import type { Asset } from '../../Openfort/types'
 import { getAssetSymbol } from '../Send/utils'
 
@@ -23,16 +23,24 @@ export type OnrampQuote = {
   exchangeRate: string
 }
 
-// Map chain IDs to network names
-const getNetworkName = (chainId: number): string => {
-  const networkMap: Record<number, string> = {
-    1: 'ethereum',
-    8453: 'base',
-    137: 'polygon',
-    42161: 'arbitrum',
-    10: 'optimism',
-  }
-  return networkMap[chainId] || 'base'
+/** EVM chain id → onramp network name. */
+const EVM_NETWORK_MAP: Record<number, string> = {
+  1: 'ethereum',
+  8453: 'base',
+  137: 'polygon',
+  42161: 'arbitrum',
+  10: 'optimism',
+}
+
+/**
+ * Resolve the onramp destination network for the active chain. Solana always
+ * resolves to `solana`; an EVM wallet whose `chainId` hasn't loaded yet returns
+ * `undefined`, so callers stay gated until the chain is ready.
+ */
+export function resolveOnrampNetwork(chainType: ChainTypeEnum, chainId?: number): string | undefined {
+  if (chainType === ChainTypeEnum.SVM) return 'solana'
+  if (chainId == null) return undefined
+  return EVM_NETWORK_MAP[chainId] ?? 'base'
 }
 
 // Map token symbol to currency code
@@ -42,7 +50,7 @@ const getCurrencyCode = (token: Asset): string => {
 
 type GetAllQuotesParams = {
   token: Asset
-  chainId: number
+  network: string
   publishableKey: string
   sourceCurrency: string
   sourceAmount: string
@@ -53,7 +61,7 @@ type GetAllQuotesParams = {
  * Calls the backend without specifying a provider to get quotes from all providers
  */
 export const getAllQuotes = async (params: GetAllQuotesParams): Promise<OnrampQuote[]> => {
-  const { token, chainId, publishableKey, sourceCurrency, sourceAmount } = params
+  const { token, network, publishableKey, sourceCurrency, sourceAmount } = params
 
   if (!publishableKey) {
     throw new Error('Publishable key is required for authentication')
@@ -62,7 +70,7 @@ export const getAllQuotes = async (params: GetAllQuotesParams): Promise<OnrampQu
   // Build request body WITHOUT provider to get all quotes
   const requestBody = {
     destinationCurrency: getCurrencyCode(token),
-    destinationNetwork: getNetworkName(chainId),
+    destinationNetwork: network,
     sourceCurrency: sourceCurrency.toLowerCase(),
     sourceAmount,
   }

--- a/packages/openfort-react/src/components/Pages/Buy/solanaCurrencies.ts
+++ b/packages/openfort-react/src/components/Pages/Buy/solanaCurrencies.ts
@@ -1,0 +1,24 @@
+import type { Hex } from 'viem'
+import type { Asset } from '../../Openfort/types'
+import { DEST_USDC_SOL } from '../Deposit/sources'
+
+/**
+ * Buyable Solana destination currencies for the fiat onramp. USDC is first so it
+ * is the default; both are supported by Coinbase and Stripe on Solana. Balances
+ * aren't needed (you're buying), so these carry zero balance — only the symbol
+ * feeds the onramp `destinationCurrency`. The USDC `address` is the SPL mint cast
+ * to `Hex` to fit the shared `Asset` type; it's only read by `getAssetSymbol`.
+ */
+export const SOLANA_BUY_CURRENCIES: Asset[] = [
+  {
+    type: 'erc20',
+    address: DEST_USDC_SOL as Hex,
+    balance: BigInt(0),
+    metadata: { symbol: 'USDC', name: 'USD Coin', decimals: 6 },
+  },
+  {
+    type: 'native',
+    balance: BigInt(0),
+    metadata: { symbol: 'SOL', decimals: 9, fiat: { value: 0, currency: 'USD' } },
+  },
+]

--- a/packages/openfort-react/src/components/Pages/Buy/stripeApi.ts
+++ b/packages/openfort-react/src/components/Pages/Buy/stripeApi.ts
@@ -39,18 +39,6 @@ type CreateStripeSessionParams = {
   redirectUrl?: string
 }
 
-// Map chain IDs to Stripe network names
-const getNetworkName = (chainId: number): string => {
-  const networkMap: Record<number, string> = {
-    1: 'ethereum',
-    8453: 'base',
-    137: 'polygon',
-    42161: 'arbitrum',
-    10: 'optimism',
-  }
-  return networkMap[chainId] || 'base'
-}
-
 // Stripe supported currencies
 const STRIPE_SUPPORTED_CURRENCIES = ['btc', 'eth', 'xlm', 'matic', 'pol', 'sol', 'usdc', 'avax', 'wld'] as const
 
@@ -82,18 +70,18 @@ const getCurrencyCode = (token: Asset): string => {
 export const createStripeSession = async (
   params: Omit<CreateStripeSessionParams, 'destinationCurrency' | 'destinationNetwork'> & {
     token: Asset
-    chainId: number
+    network: string
     publishableKey: string
   }
 ): Promise<StripeOnrampResponse> => {
-  const { token, chainId, publishableKey, destinationAddress, sourceAmount, sourceCurrency, redirectUrl } = params
+  const { token, network, publishableKey, destinationAddress, sourceAmount, sourceCurrency, redirectUrl } = params
 
   if (!publishableKey) {
     throw new Error('Publishable key is required for authentication')
   }
 
   const destinationCurrency = getCurrencyCode(token)
-  const destinationNetwork = getNetworkName(chainId)
+  const destinationNetwork = network
 
   // Build request body for backend API
   const requestBody: CreateStripeSessionParams & { provider: string } = {
@@ -138,11 +126,11 @@ type GetStripeQuoteParams = {
 const _getStripeQuote = async (
   params: Omit<GetStripeQuoteParams, 'destinationCurrency' | 'destinationNetwork'> & {
     token: Asset
-    chainId: number
+    network: string
     publishableKey: string
   }
 ): Promise<StripeQuote> => {
-  const { token, chainId, publishableKey, ...rest } = params
+  const { token, network, publishableKey, ...rest } = params
 
   if (!publishableKey) {
     throw new Error('Publishable key is required for authentication')
@@ -152,7 +140,7 @@ const _getStripeQuote = async (
   const requestBody: GetStripeQuoteParams & { provider: string } = {
     provider: 'stripe',
     destinationCurrency: getCurrencyCode(token),
-    destinationNetwork: getNetworkName(chainId),
+    destinationNetwork: network,
     sourceCurrency: rest.sourceCurrency.toLowerCase(),
     sourceAmount: rest.sourceAmount,
   }

--- a/packages/openfort-react/src/components/Pages/BuyComplete/index.tsx
+++ b/packages/openfort-react/src/components/Pages/BuyComplete/index.tsx
@@ -48,7 +48,13 @@ const BuyComplete = () => {
     setRoute(routes.CONNECTED)
   }
 
-  const blockExplorerUrl = address && chainId ? getExplorerUrl(ChainTypeEnum.EVM, { chainId, address }) : ''
+  const blockExplorerUrl = !address
+    ? ''
+    : chainType === ChainTypeEnum.SVM
+      ? getExplorerUrl(ChainTypeEnum.SVM, { address, cluster: solanaWallet.cluster })
+      : chainId
+        ? getExplorerUrl(ChainTypeEnum.EVM, { chainId, address })
+        : ''
 
   return (
     <PageContent onBack={handleBack}>

--- a/packages/openfort-react/src/components/Pages/BuyProcessing/index.tsx
+++ b/packages/openfort-react/src/components/Pages/BuyProcessing/index.tsx
@@ -15,6 +15,8 @@ import { routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
 import { createCoinbaseSession } from '../Buy/coinbaseApi'
+import { resolveOnrampNetwork } from '../Buy/onrampApi'
+import { SOLANA_BUY_CURRENCIES } from '../Buy/solanaCurrencies'
 import { createStripeSession } from '../Buy/stripeApi'
 import { ContinueButtonWrapper, PendingContainer, StackedButtonWrapper } from '../Buy/styles'
 import { isSameToken } from '../Send/utils'
@@ -31,13 +33,15 @@ const BuyProcessing = () => {
   const isConnected = wallet.status === 'connected'
   const address = isConnected ? wallet.address : undefined
   const chainId = isConnected && chainType === ChainTypeEnum.EVM ? (wallet as typeof ethereumWallet).chainId : undefined
+  const network = resolveOnrampNetwork(chainType, chainId)
 
   const [popupWindow, setPopupWindow] = useState<Window | null>(null)
   const [showContinueButton, setShowContinueButton] = useState(false)
   const [isCreatingSession, setIsCreatingSession] = useState(true)
   const [sessionError, setSessionError] = useState(false)
 
-  const { data: assets } = useEthereumWalletAssets()
+  const { data: ethAssets } = useEthereumWalletAssets()
+  const assets = chainType === ChainTypeEnum.SVM ? SOLANA_BUY_CURRENCIES : ethAssets
 
   const matchedToken = useMemo(
     () => assets?.find((asset) => isSameToken(asset, buyForm.asset)),
@@ -58,7 +62,7 @@ const BuyProcessing = () => {
   // Create session and open popup once wallet is ready
   const sessionStartedRef = useRef(false)
   useEffect(() => {
-    if (!address || !chainId) return
+    if (!address || !network) return
     if (sessionStartedRef.current) return
     sessionStartedRef.current = true
 
@@ -78,7 +82,7 @@ const BuyProcessing = () => {
         if (buyForm.providerId === 'coinbase') {
           const session = await createCoinbaseSession({
             token: selectedToken,
-            chainId,
+            network,
             publishableKey,
             destinationAddress: address,
             sourceAmount: fiatAmount.toFixed(2),
@@ -89,7 +93,7 @@ const BuyProcessing = () => {
         } else if (buyForm.providerId === 'stripe') {
           const session = await createStripeSession({
             token: selectedToken,
-            chainId,
+            network,
             publishableKey,
             destinationAddress: address,
             sourceAmount: fiatAmount.toFixed(2),
@@ -148,7 +152,7 @@ const BuyProcessing = () => {
     }
 
     createSessionAndOpenPopup()
-  }, [address, chainId]) // Run when wallet becomes ready
+  }, [address, network]) // Run when wallet becomes ready
 
   // Trigger resize on mount and when state changes
   useEffect(() => {

--- a/packages/openfort-react/src/components/Pages/BuySelectProvider/index.tsx
+++ b/packages/openfort-react/src/components/Pages/BuySelectProvider/index.tsx
@@ -13,8 +13,9 @@ import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
 import { isCoinbaseSupported } from '../Buy/coinbaseApi'
 import type { OnrampQuote } from '../Buy/onrampApi'
-import { getAllQuotes } from '../Buy/onrampApi'
+import { getAllQuotes, resolveOnrampNetwork } from '../Buy/onrampApi'
 import { getProviders } from '../Buy/providers'
+import { SOLANA_BUY_CURRENCIES } from '../Buy/solanaCurrencies'
 import { isStripeSupported } from '../Buy/stripeApi'
 import {
   ContinueButtonWrapper,
@@ -44,6 +45,9 @@ const BuySelectProvider = () => {
   const isConnected = wallet.status === 'connected'
   const address = isConnected ? wallet.address : undefined
   const chainId = isConnected && chainType === ChainTypeEnum.EVM ? (wallet as typeof ethereumWallet).chainId : undefined
+  // The onramp destination network: 'solana' for SVM, else the EVM network (undefined
+  // until the EVM chainId resolves, which keeps quote fetching gated as before).
+  const network = resolveOnrampNetwork(chainType, chainId)
 
   const [quotes, setQuotes] = useState<Record<string, OnrampQuote>>({})
   const [isLoadingQuote, setIsLoadingQuote] = useState(false)
@@ -60,7 +64,8 @@ const BuySelectProvider = () => {
     return numeric
   }, [buyForm.amount])
 
-  const { data: assets } = useEthereumWalletAssets()
+  const { data: ethAssets } = useEthereumWalletAssets()
+  const assets = chainType === ChainTypeEnum.SVM ? SOLANA_BUY_CURRENCIES : ethAssets
 
   const matchedToken = useMemo(
     () => assets?.find((asset) => isSameToken(asset, buyForm.asset)),
@@ -105,7 +110,7 @@ const BuySelectProvider = () => {
   // Fetch quotes from all providers
   useEffect(() => {
     const fetchQuotes = async () => {
-      if (!address || !chainId || !fiatAmount || fiatAmount <= 0) {
+      if (!address || !network || !fiatAmount || fiatAmount <= 0) {
         setQuotes({})
         setCoinbaseError(false)
         setStripeError(false)
@@ -119,7 +124,7 @@ const BuySelectProvider = () => {
       try {
         const allQuotes = await getAllQuotes({
           token: selectedToken,
-          chainId,
+          network,
           publishableKey,
           sourceAmount: fiatAmount.toFixed(2),
           sourceCurrency: buyForm.currency,
@@ -151,7 +156,7 @@ const BuySelectProvider = () => {
     selectedToken.metadata,
     selectedToken.type,
     buyForm.currency,
-    chainId,
+    network,
     address,
     publishableKey,
     refetchTrigger,

--- a/packages/openfort-react/src/components/Pages/Deposit/index.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/index.tsx
@@ -1,15 +1,18 @@
 'use client'
 
+import { ChainTypeEnum } from '@openfort/openfort-js'
 import type { ReactNode, SyntheticEvent } from 'react'
 import { BuyIcon, DollarIcon, ExternalLinkIcon, ReceiveIcon, WalletIcon } from '../../../assets/icons'
 import logos from '../../../assets/logos'
 import { useFunding } from '../../../hooks/openfort/useFunding'
 import { useFundingChains } from '../../../hooks/openfort/useFundingChains'
 import useIsMobile from '../../../hooks/useIsMobile'
+import { useOpenfortCore } from '../../../openfort/useOpenfort'
 import { ModalHeading } from '../../Common/Modal/styles'
 import { FundingMethod, routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
+import { SOLANA_BUY_CURRENCIES } from '../Buy/solanaCurrencies'
 import { type DepositMethodTarget, getPaymentOptions } from './paymentOptions'
 import {
   DepositContent,
@@ -57,6 +60,7 @@ const hideBrokenLogo = (e: SyntheticEvent<HTMLImageElement>) => {
  */
 const Deposit = () => {
   const { setRoute, setBuyForm, uiConfig } = useOpenfort()
+  const { chainType } = useOpenfortCore()
   const isMobile = useIsMobile()
   const { isAvailable } = useFunding()
   const { chains } = useFundingChains()
@@ -105,7 +109,13 @@ const Deposit = () => {
     }
     // Fiat rails reuse the existing Buy flow; preselect the chosen provider so
     // Apple Pay / Card land on the right rail.
-    setBuyForm((prev) => ({ ...prev, providerId: target.providerId }))
+    setBuyForm((prev) => ({
+      ...prev,
+      providerId: target.providerId,
+      // Default the Solana card-buy to USDC — the native-asset default would
+      // otherwise resolve to SOL (isSameToken treats any two natives as equal).
+      ...(chainType === ChainTypeEnum.SVM ? { asset: SOLANA_BUY_CURRENCIES[0] } : {}),
+    }))
     setRoute(routes.BUY)
   }
 

--- a/packages/openfort-react/src/components/Pages/SelectToken/index.tsx
+++ b/packages/openfort-react/src/components/Pages/SelectToken/index.tsx
@@ -1,12 +1,15 @@
 'use client'
 
+import { ChainTypeEnum } from '@openfort/openfort-js'
 import { useEffect, useState } from 'react'
 import { formatUnits } from 'viem'
 import { useEthereumWalletAssets } from '../../../ethereum/hooks/useEthereumWalletAssets'
+import { useOpenfortCore } from '../../../openfort/useOpenfort'
 import { Arrow, ArrowChevron, TextLinkButton } from '../../Common/Button/styles'
 import { ModalHeading } from '../../Common/Modal/styles'
 import { type Asset, routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
+import { SOLANA_BUY_CURRENCIES } from '../Buy/solanaCurrencies'
 import { formatBalanceWithSymbol, getAssetDecimals, getAssetSymbol } from '../Send/utils'
 import {
   EmptyState,
@@ -36,10 +39,12 @@ const SelectToken = ({ isBuyFlow }: { isBuyFlow: boolean }) => {
     triggerResize()
   }, [viewAllAssets])
 
+  const { chainType } = useOpenfortCore()
   const { data: walletAssets, isLoading: isBalancesLoading } = useEthereumWalletAssets()
 
-  // Show all tokens for both buy and send flows
-  const selectableTokens = walletAssets || []
+  // Solana buys pick from a fixed currency list (USDC, SOL); everything else reads
+  // the EVM wallet's assets. (Solana send doesn't use this picker.)
+  const selectableTokens = isBuyFlow && chainType === ChainTypeEnum.SVM ? SOLANA_BUY_CURRENCIES : walletAssets || []
 
   const handleSelect = (asset: Asset) => {
     // In send flow, don't allow selecting tokens with 0 balance


### PR DESCRIPTION
The **Add funds → Card** flow was EVM-only: it read currencies from `useEthereumWalletAssets` and gated on the EVM numeric `chainId` (undefined for Solana → no quotes, no session), and the three onramp API files derived `destinationNetwork` from `chainId` with no Solana case (defaulted to `base`). So on a Solana wallet the card-buy showed EVM currencies and couldn't complete. This adapts it.

## What's in it
- **`resolveOnrampNetwork(chainType, chainId)`** (`Buy/onrampApi.ts`) — `'solana'` for SVM, the EVM map otherwise, `undefined` until an EVM chainId resolves (keeps EVM gated as before). The 3 API files now take a resolved **`network`** string instead of `chainId`.
- **`Buy/solanaCurrencies.ts`** — a static buyable list: **USDC** (default) + **SOL**, both supported by Coinbase and Stripe on Solana.
- **`Buy` / `BuySelectProvider` / `BuyProcessing` / `SelectToken`** — chain-aware currency list + `network` gate (was `chainId`); the **Deposit hub** seeds the Solana card-buy with USDC.
- **`BuyComplete`** — Solana explorer link (was EVM-only).

## Decision
Offers **USDC + SOL**, default **USDC** (matches the Deposit hub's Solana default and the stablecoin focus).

## Verify
`pnpm build` ✅ · `biome` clean · `vitest` → **201 passing** (incl. `resolveOnrampNetwork`). Dogfooded in the playground (Solana mode): Add funds → Card → the Currency defaults to **USDC** and the picker offers **SOL**.

> **Backend dependency:** `/v1/onramp/{quotes,sessions}` must accept `destinationNetwork: 'solana'`. Coinbase Onramp and Stripe both support Solana and the backend is a passthrough, so this is expected to work; if it rejects `solana`, the existing graceful error path shows and the backend needs a one-line allowlist update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)