### PR TITLE
fix(funding): Deposit hub base URL, target address, and review fixes

### DIFF
--- a/.changeset/funding-default-base-url.md
+++ b/.changeset/funding-default-base-url.md
@@ -1,0 +1,5 @@
+---
+'@openfort/react': patch
+---
+
+Default `uiConfig.fundingBaseUrl` to the SDK's backend URL (`api.openfort.io`). The Deposit hub's crypto rails (`useFunding`, `useFundingChains`) previously required `fundingBaseUrl` to be set or they stayed hidden, while the CEX rail already fell back to the backend — an inconsistency. Both now resolve to `uiConfig.fundingBaseUrl || backendUrl`, so the funding rails work out of the box; set `fundingBaseUrl` only to point at a custom funding service.

--- a/.changeset/funding-deposit-modal-fixes.md
+++ b/.changeset/funding-deposit-modal-fixes.md
@@ -1,0 +1,10 @@
+---
+'@openfort/react': patch
+---
+
+Deposit hub fixes:
+
+- Resolve the deposit recipient by the funding target's chain family, not the active chain type. A target/wallet family mismatch (e.g. an EVM session whose funding target is still Solana) previously sent an EVM address as the recipient for a Solana destination, which Relay rejected.
+- Offer the destination chain itself as a source, so same-chain deposits (e.g. Solana → Solana) show as a plain transfer to the wallet address alongside the cross-chain bridge routes.
+- Default the card / Apple Pay buy to USDC on EVM (matching Solana). The picker now lists buyable currencies (USDC, native) instead of the wallet's indexed balances, so a freshly created wallet no longer shows "No supported tokens found".
+- Update Deposit method subtitles: "Bridge fee" (was "No fee") for the wallet/address rails, and a $5 minimum for the exchange rail.

--- a/.changeset/funding-drop-target-address.md
+++ b/.changeset/funding-drop-target-address.md
@@ -1,0 +1,5 @@
+---
+'@openfort/react': patch
+---
+
+Drop the `uiConfig.funding.targetAddress` override. Deposits always settle into the user's active embedded wallet (the address the SDK already resolves and sends to Relay as the recipient), so the override was a no-op on the deposit-address and CEX rails. `useFundingTarget` now returns `{ chain, currency }` and `FundingUIOptions` no longer accepts `targetAddress`.

--- a/.changeset/funding-solana-wallet-deeplink.md
+++ b/.changeset/funding-solana-wallet-deeplink.md
@@ -1,0 +1,5 @@
+---
+'@openfort/react': patch
+---
+
+Show Phantom in "Transfer from wallet" for Solana sources. Solana sources have no numeric chain id and no desktop EVM-extension send, so they previously rendered no wallets at all. The deposit deeplink is now VM-aware (`buildDepositPageUrl` emits `vm=svm` with the SPL mint and base58 recipient instead of a numeric `chainId`), and Solana sources route through the deeplink (Phantom) on every platform. Pairs with the deposit page's new Solana Pay path.

--- a/.changeset/funding-wallet-amount-input.md
+++ b/.changeset/funding-wallet-amount-input.md
@@ -1,0 +1,5 @@
+---
+'@openfort/react': patch
+---
+
+Add an amount input with preset buttons to the Deposit hub's "Transfer from wallet" rail, matching the exchange rail. Pick a source chain and token, enter (or tap a preset for) an amount, then choose the wallet — the amount prefills the wallet deeplink (mobile) and the direct send (desktop). The amount is owned by the page and shared across both paths, replacing the two separate per-path inputs.

--- a/.changeset/funding-wallet-send-feedback.md
+++ b/.changeset/funding-wallet-send-feedback.md
@@ -1,0 +1,5 @@
+---
+'@openfort/react': patch
+---
+
+Reveal the desktop "Transfer from wallet" send feedback. `DepositWalletDesktop` never triggered a modal resize, so the "Confirm in your wallet…" status and the insufficient-balance message ("Not enough X — you have Y") were clipped below the fold — a click on a wallet with too little balance read as "nothing happened". The modal now resizes when that feedback toggles.

--- a/examples/playground/.env.local.example
+++ b/examples/playground/.env.local.example
@@ -8,7 +8,7 @@ VITE_SHIELD_PUBLISHABLE_KEY=
 # VITE_API_URL=https://api.openfort.io
 # VITE_SHIELD_URL=https://shield.openfort.io
 # VITE_IFRAME_API_URL — SDK default is https://embed.openfort.io; only override for local development
-# VITE_FUNDING_BASE_URL — funding/Deposit backend; SDK default is https://funding.openfort.io, override for a local backend
+# VITE_FUNDING_BASE_URL — funding/Deposit JSON API (serves /v2/funding/*); SDK default is https://api.openfort.io, override for a local backend
 
 # Required for AUTOMATIC wallet recovery: backend endpoint that creates an encryption session
 # See: https://github.com/openfort-xyz/openfort-backend-quickstart
@@ -25,6 +25,3 @@ VITE_FEE_SPONSORSHIP_ID=
 
 # Optional: mint contract addresses (chain-dependent)
 VITE_POLYGON_MINT_CONTRACT=
-
-
-VITE_FUNDING_BASE_URL=

--- a/examples/playground/src/lib/chains.ts
+++ b/examples/playground/src/lib/chains.ts
@@ -71,6 +71,14 @@ export function getFundingTargetForChain(
   return { targetChain: `eip155:${chain.id}`, targetCurrency: chain.usdc }
 }
 
+/**
+ * Fallback EVM funding target (Base USDC) for chains without a configured USDC
+ * (testnets). Keeps the Deposit target on an EVM chain in EVM mode rather than
+ * leaving a stale Solana target from a prior SVM session — a Solana target with
+ * an EVM recipient makes Relay reject the route.
+ */
+export const DEFAULT_EVM_FUNDING_TARGET = getFundingTargetForChain(base.id)!
+
 export function getPlaygroundRpcUrl(chainId?: number): string {
   if (chainId != null && RPC_URLS[chainId]) return RPC_URLS[chainId]
   return DEFAULT_EVM_CHAIN.rpcUrl

--- a/examples/playground/src/lib/useAppStore.ts
+++ b/examples/playground/src/lib/useAppStore.ts
@@ -73,7 +73,7 @@ const defaultProviderOptions: Parameters<typeof OpenfortProvider>[0] = {
         'eip155:1',
         'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
       ],
-      sourceCurrencies: ['ETH', 'WETH', 'USDC', 'USDT', 'DAI'],
+      sourceCurrencies: ['ETH', 'USDC', 'USDT', 'DAI'],
       targetChain: 'eip155:8453',
       targetCurrency: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
       // depositPageUrl omitted → uses the SDK default (https://deposit.openfort.io),

--- a/examples/playground/src/lib/useAppStore.ts
+++ b/examples/playground/src/lib/useAppStore.ts
@@ -54,11 +54,11 @@ const defaultProviderOptions: Parameters<typeof OpenfortProvider>[0] = {
   publishableKey: import.meta.env.VITE_OPENFORT_PUBLISHABLE_KEY,
 
   uiConfig: {
-    // Funding rail backend (independent of the auth/wallet api): drives the
-    // Deposit widget while auth/wallet use the real Openfort api. Drives
-    // useFunding().isAvailable. Defaults to the hosted funding api; set
-    // VITE_FUNDING_BASE_URL (see .env.local) to point at a local backend.
-    fundingBaseUrl: import.meta.env.VITE_FUNDING_BASE_URL || 'https://funding.openfort.io',
+    // Funding rail JSON API: serves /v2/funding/* (chains + sessions) and drives
+    // the Deposit widget / useFunding().isAvailable. Consolidated into the main
+    // Openfort api; set VITE_FUNDING_BASE_URL (see .env.local) to point at a local
+    // backend. Not to be confused with depositPageUrl (the hosted Deposit page).
+    fundingBaseUrl: import.meta.env.VITE_FUNDING_BASE_URL || 'https://api.openfort.io',
     // Mainnet e2e: source major tokens from mainnet chains, land on Base mainnet
     // USDC (the live embedded wallet's chain). Explicit symbols (not the 'native'
     // sentinel) so only Relay-supported deposit-address tokens show — e.g. ETH is

--- a/examples/playground/src/lib/useAppStore.ts
+++ b/examples/playground/src/lib/useAppStore.ts
@@ -65,7 +65,14 @@ const defaultProviderOptions: Parameters<typeof OpenfortProvider>[0] = {
     // routable but Polygon's POL isn't ("major tokens" only). ETH uses a 0.01-unit
     // mint nominal so it isn't 1 whole ETH (see nominalUnits).
     funding: {
-      sourceChains: ['eip155:42161', 'eip155:8453', 'eip155:10', 'eip155:137', 'eip155:1'],
+      sourceChains: [
+        'eip155:42161',
+        'eip155:8453',
+        'eip155:10',
+        'eip155:137',
+        'eip155:1',
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      ],
       sourceCurrencies: ['ETH', 'WETH', 'USDC', 'USDT', 'DAI'],
       targetChain: 'eip155:8453',
       targetCurrency: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',

--- a/examples/playground/src/providers.tsx
+++ b/examples/playground/src/providers.tsx
@@ -15,7 +15,12 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import { createConfig, http, useChainId, WagmiProvider } from 'wagmi'
 import { ThemeProvider } from '@/components/theme-provider'
 import { EthereumAddressProviderEmbedded, EthereumAddressProviderWagmi } from '@/contexts/EthereumAddressContext'
-import { getFundingTargetForChain, PLAYGROUND_EVM_CHAINS, SOLANA_FUNDING_TARGET } from '@/lib/chains'
+import {
+  DEFAULT_EVM_FUNDING_TARGET,
+  getFundingTargetForChain,
+  PLAYGROUND_EVM_CHAINS,
+  SOLANA_FUNDING_TARGET,
+} from '@/lib/chains'
 import { useAppStore } from './lib/useAppStore'
 
 export type OpenfortPlaygroundMode = 'svm' | 'evm'
@@ -110,8 +115,10 @@ const MODE_TO_CHAIN = { evm: ChainTypeEnum.EVM, svm: ChainTypeEnum.SVM } as cons
 /**
  * Keeps the Deposit-hub funding target in sync with the active EVM chain, so
  * switching networks in the OpenfortButton lands deposits on that chain's USDC.
- * No-ops on chains without a configured USDC (testnets), keeping the prior target.
- * Deposits land on the active EVM embedded wallet, resolved by the Deposit hub.
+ * Chains without a configured USDC (testnets) fall back to Base USDC, so EVM mode
+ * never keeps a stale Solana target from a prior SVM session (which would make the
+ * EVM recipient invalid for the Solana destination). Deposits land on the active
+ * EVM embedded wallet, resolved by the Deposit hub.
  */
 function FundingTargetSync() {
   const chainId = useChainId()
@@ -119,8 +126,7 @@ function FundingTargetSync() {
   const setProviderOptions = useAppStore((s) => s.setProviderOptions)
 
   useEffect(() => {
-    const target = getFundingTargetForChain(chainId)
-    if (!target) return
+    const target = getFundingTargetForChain(chainId) ?? DEFAULT_EVM_FUNDING_TARGET
     const funding = providerOptions.uiConfig?.funding
     if (funding?.targetChain === target.targetChain && funding?.targetCurrency === target.targetCurrency) {
       return

--- a/examples/playground/src/providers.tsx
+++ b/examples/playground/src/providers.tsx
@@ -8,7 +8,6 @@
  */
 
 import { ChainTypeEnum, OpenfortProvider } from '@openfort/react'
-import { useSolanaEmbeddedWallet } from '@openfort/react/solana'
 import { getDefaultConfig, getDefaultConnectors, OpenfortWagmiBridge } from '@openfort/react/wagmi'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type React from 'react'
@@ -112,8 +111,7 @@ const MODE_TO_CHAIN = { evm: ChainTypeEnum.EVM, svm: ChainTypeEnum.SVM } as cons
  * Keeps the Deposit-hub funding target in sync with the active EVM chain, so
  * switching networks in the OpenfortButton lands deposits on that chain's USDC.
  * No-ops on chains without a configured USDC (testnets), keeping the prior target.
- * Drops any `targetAddress` so deposits land on the active EVM embedded wallet —
- * clears a stale Solana address left by the SVM sync after a mode switch.
+ * Deposits land on the active EVM embedded wallet, resolved by the Deposit hub.
  */
 function FundingTargetSync() {
   const chainId = useChainId()
@@ -124,19 +122,14 @@ function FundingTargetSync() {
     const target = getFundingTargetForChain(chainId)
     if (!target) return
     const funding = providerOptions.uiConfig?.funding
-    if (
-      funding?.targetChain === target.targetChain &&
-      funding?.targetCurrency === target.targetCurrency &&
-      funding?.targetAddress === undefined
-    ) {
+    if (funding?.targetChain === target.targetChain && funding?.targetCurrency === target.targetCurrency) {
       return
     }
-    const { targetAddress: _drop, ...rest } = funding ?? {}
     setProviderOptions({
       ...providerOptions,
       uiConfig: {
         ...providerOptions.uiConfig,
-        funding: { ...rest, ...target },
+        funding: { ...funding, ...target },
       },
     })
   }, [chainId, providerOptions, setProviderOptions])
@@ -146,27 +139,23 @@ function FundingTargetSync() {
 
 /**
  * SVM counterpart of {@link FundingTargetSync}: while in Solana mode, points the
- * Deposit-hub target at Solana mainnet USDC and the active Solana embedded wallet,
- * so a Coinbase/crypto deposit bridges and lands as USDC in that wallet.
+ * Deposit-hub target at Solana mainnet USDC, so a Coinbase/crypto deposit bridges
+ * and lands as USDC in the active Solana embedded wallet (resolved by the Deposit
+ * hub from the SVM embedded account).
  *
  * Mirrors the EVM sync: flip the target chain/currency to Solana *immediately* on
  * mount (this component only renders in SVM mode), not gated on the wallet being
- * fully connected. `targetAddress` is set once the Solana wallet resolves; until
- * then DepositCex falls back to the SVM embedded account, so the CEX page never
- * strands on "Preparing…" while the wallet is still connecting.
+ * fully connected, so the CEX page never strands on "Preparing…".
  */
 function SolanaFundingTargetSync() {
-  const solana = useSolanaEmbeddedWallet()
   const providerOptions = useAppStore((s) => s.providerOptions)
   const setProviderOptions = useAppStore((s) => s.setProviderOptions)
-  const address = solana.status === 'connected' ? solana.activeWallet?.address : undefined
 
   useEffect(() => {
     const funding = providerOptions.uiConfig?.funding
     if (
       funding?.targetChain === SOLANA_FUNDING_TARGET.targetChain &&
-      funding?.targetCurrency === SOLANA_FUNDING_TARGET.targetCurrency &&
-      funding?.targetAddress === address
+      funding?.targetCurrency === SOLANA_FUNDING_TARGET.targetCurrency
     ) {
       return
     }
@@ -174,10 +163,10 @@ function SolanaFundingTargetSync() {
       ...providerOptions,
       uiConfig: {
         ...providerOptions.uiConfig,
-        funding: { ...funding, ...SOLANA_FUNDING_TARGET, targetAddress: address },
+        funding: { ...funding, ...SOLANA_FUNDING_TARGET },
       },
     })
-  }, [address, providerOptions, setProviderOptions])
+  }, [providerOptions, setProviderOptions])
 
   return null
 }

--- a/packages/openfort-react/src/__tests__/useDepositRoute.test.ts
+++ b/packages/openfort-react/src/__tests__/useDepositRoute.test.ts
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Drive the chain-aware receiver resolution by stubbing the boundary hooks.
 // The funding chains list is empty so the fund() effect short-circuits — we only
-// assert which embedded wallet supplies the destination address.
+// assert which embedded wallet supplies the destination address. The recipient is
+// resolved by the funding target's chain family (which tracks the active chain
+// type), so the target mock below mirrors useFundingTarget's chain-aware default.
 let mockChainType: ChainTypeEnum = ChainTypeEnum.EVM
 const mockEthWallet: { status: string; address?: string } = { status: 'disconnected' }
 const mockSolWallet: { status: string; address?: string } = { status: 'disconnected' }
@@ -34,7 +36,10 @@ vi.mock('../hooks/openfort/useFundingChains', () => ({
   nominalUnits: (decimals: number) => `1${'0'.repeat(decimals + 1)}`,
 }))
 vi.mock('../components/Pages/Deposit/useFundingTarget', () => ({
-  useFundingTarget: () => ({ chain: 'eip155:8453', currency: '0xUSDC', address: undefined }),
+  useFundingTarget: () => ({
+    chain: mockChainType === ChainTypeEnum.SVM ? 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' : 'eip155:8453',
+    currency: '0xUSDC',
+  }),
 }))
 
 const { useDepositRoute } = await import('../components/Pages/Deposit/useDepositRoute')

--- a/packages/openfort-react/src/__tests__/useFunding.test.ts
+++ b/packages/openfort-react/src/__tests__/useFunding.test.ts
@@ -54,15 +54,12 @@ describe('useFunding', () => {
     mockUiConfig.fundingBaseUrl = undefined
   })
 
-  it('is unavailable and refuses to fund when no client is configured', async () => {
+  it('is available by default — fundingBaseUrl falls back to the backend', () => {
+    // No fundingBaseUrl set and no SDK backend configured in tests, so it resolves
+    // to the hardcoded api.openfort.io default and the rail is available.
     const { result } = renderHook(() => useFunding())
-    expect(result.current.isAvailable).toBe(false)
+    expect(result.current.isAvailable).toBe(true)
     expect(result.current.status).toBe('idle')
-
-    await act(async () => {
-      await expect(result.current.fund(target, paymentMethod)).rejects.toThrow('not configured')
-    })
-    expect(result.current.error?.message).toMatch('not configured')
   })
 
   it('creates a session, sets the payment method, and surfaces a terminal status without polling', async () => {

--- a/packages/openfort-react/src/components/Openfort/types.ts
+++ b/packages/openfort-react/src/components/Openfort/types.ts
@@ -358,13 +358,9 @@ export type ConnectUIOptions = {
   buyFromExchangeUrl?: string
   buyTroubleshootingUrl?: string
   /**
-   * Base URL of the funding JSON API serving `/v2/funding/*` (e.g.
-   * `https://api.openfort.io`). Powers the Deposit hub's crypto/CEX rails (chains +
-   * session API). When omitted, those rails are unavailable and the network layer
-   * is a no-op.
-   *
-   * TODO(openfort-funding-backend): default this from the platform config so
-   * integrators don't have to set it manually.
+   * Base URL of the funding JSON API serving `/v2/funding/*` (chains + sessions).
+   * Defaults to the SDK's backend URL (`https://api.openfort.io`); set this only to
+   * point the Deposit hub's crypto rails at a custom funding service.
    */
   fundingBaseUrl?: string
   /** Deposit-hub funding options (destination chain/token for incoming deposits). */

--- a/packages/openfort-react/src/components/Openfort/types.ts
+++ b/packages/openfort-react/src/components/Openfort/types.ts
@@ -410,11 +410,6 @@ export type FundingUIOptions = {
    */
   targetCurrency?: string
   /**
-   * Destination wallet that receives the deposit. Optional integrator override;
-   * when unset, deposits land on the active embedded wallet for the target chain.
-   */
-  targetAddress?: string
-  /**
    * Which funding methods the Deposit hub shows, and in what order. Omit to show
    * all available methods (Apple Pay first on mobile). Mirrors `authProviders`.
    * @example [FundingMethod.WALLET, FundingMethod.ADDRESS]

--- a/packages/openfort-react/src/components/Openfort/types.ts
+++ b/packages/openfort-react/src/components/Openfort/types.ts
@@ -358,12 +358,13 @@ export type ConnectUIOptions = {
   buyFromExchangeUrl?: string
   buyTroubleshootingUrl?: string
   /**
-   * Base URL of the openfort-funding backend (e.g. `https://funding.openfort.io`).
-   * Powers the Deposit hub's crypto/CEX rails (session API). When omitted, those
-   * rails are unavailable and the network layer is a no-op.
+   * Base URL of the funding JSON API serving `/v2/funding/*` (e.g.
+   * `https://api.openfort.io`). Powers the Deposit hub's crypto/CEX rails (chains +
+   * session API). When omitted, those rails are unavailable and the network layer
+   * is a no-op.
    *
-   * TODO(openfort-funding-backend): default this from the platform config once the
-   * backend ships, so integrators don't have to set it manually.
+   * TODO(openfort-funding-backend): default this from the platform config so
+   * integrators don't have to set it manually.
    */
   fundingBaseUrl?: string
   /** Deposit-hub funding options (destination chain/token for incoming deposits). */

--- a/packages/openfort-react/src/components/Pages/Buy/evmCurrencies.ts
+++ b/packages/openfort-react/src/components/Pages/Buy/evmCurrencies.ts
@@ -1,0 +1,26 @@
+import type { Hex } from 'viem'
+import type { Asset } from '../../Openfort/types'
+import { DEST_USDC } from '../Deposit/sources'
+
+/**
+ * Buyable EVM destination currencies for the fiat onramp. USDC is first so it is
+ * the default; both are supported by Coinbase and Stripe. Balances aren't needed
+ * (you're buying), so these carry zero balance — only the symbol feeds the onramp
+ * `destinationCurrency`. The USDC `address` is Base USDC cast to `Hex` to fit the
+ * shared `Asset` type; it's only read by `getAssetSymbol`. Mirrors
+ * {@link SOLANA_BUY_CURRENCIES} so the card/Apple Pay picker always has options,
+ * even for a freshly created wallet with no indexed token balances.
+ */
+export const EVM_BUY_CURRENCIES: Asset[] = [
+  {
+    type: 'erc20',
+    address: DEST_USDC as Hex,
+    balance: BigInt(0),
+    metadata: { symbol: 'USDC', name: 'USD Coin', decimals: 6 },
+  },
+  {
+    type: 'native',
+    balance: BigInt(0),
+    metadata: { symbol: 'ETH', decimals: 18, fiat: { value: 0, currency: 'USD' } },
+  },
+]

--- a/packages/openfort-react/src/components/Pages/Deposit/index.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/index.tsx
@@ -13,6 +13,7 @@ import PoweredByFooter from '../../Common/PoweredByFooter'
 import { FundingMethod, routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
+import { EVM_BUY_CURRENCIES } from '../Buy/evmCurrencies'
 import { SOLANA_BUY_CURRENCIES } from '../Buy/solanaCurrencies'
 import { type DepositMethodTarget, getPaymentOptions } from './paymentOptions'
 import {
@@ -113,9 +114,11 @@ const Deposit = () => {
     setBuyForm((prev) => ({
       ...prev,
       providerId: target.providerId,
-      // Default the Solana card-buy to USDC — the native-asset default would
-      // otherwise resolve to SOL (isSameToken treats any two natives as equal).
-      ...(chainType === ChainTypeEnum.SVM ? { asset: SOLANA_BUY_CURRENCIES[0] } : {}),
+      // Default the card-buy to USDC per chain family. Without this the EVM default
+      // resolves to the wallet's (often empty) asset list — "no supported tokens" —
+      // and the Solana native default would resolve to SOL (isSameToken treats any
+      // two natives as equal).
+      asset: chainType === ChainTypeEnum.SVM ? SOLANA_BUY_CURRENCIES[0] : EVM_BUY_CURRENCIES[0],
     }))
     setRoute(routes.BUY)
   }

--- a/packages/openfort-react/src/components/Pages/Deposit/paymentOptions.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/paymentOptions.ts
@@ -56,19 +56,19 @@ const ALL_METHODS: DepositMethod[] = [
   {
     id: FundingMethod.WALLET,
     title: 'Transfer from wallet',
-    subtitle: 'Min $1 · No fee · 10 sec',
+    subtitle: 'Min $1 · Bridge fee · 10 sec',
     target: { kind: 'wallet' },
   },
   {
     id: FundingMethod.ADDRESS,
     title: 'Transfer from address',
-    subtitle: 'Min $1 · No fee · 10 sec',
+    subtitle: 'Min $1 · Bridge fee · 10 sec',
     target: { kind: 'crypto' },
   },
   {
     id: FundingMethod.EXCHANGE,
     title: 'Transfer from Exchange',
-    subtitle: 'Min $1 · Network fee · 2 min',
+    subtitle: 'Min $5 · Network fee · 2 min',
     target: { kind: 'cex' },
   },
 ]

--- a/packages/openfort-react/src/components/Pages/Deposit/useDepositRoute.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/useDepositRoute.ts
@@ -1,6 +1,5 @@
 'use client'
 
-import { ChainTypeEnum } from '@openfort/openfort-js'
 import { useEffect, useRef, useState } from 'react'
 import { useEthereumEmbeddedWallet } from '../../../ethereum/hooks/useEthereumEmbeddedWallet'
 import { type PaymentMethodInput, useFunding } from '../../../hooks/openfort/useFunding'
@@ -10,7 +9,6 @@ import {
   nominalUnits,
   useFundingChains,
 } from '../../../hooks/openfort/useFundingChains'
-import { useOpenfortCore } from '../../../openfort/useOpenfort'
 import { useSolanaEmbeddedWallet } from '../../../solana/hooks/useSolanaEmbeddedWallet'
 import { logger } from '../../../utils/logger'
 import { isCexDeliverable } from './cexChains'
@@ -34,17 +32,20 @@ function paymentMethodFor(chain: string, currency: FundingCurrency): PaymentMeth
  * address" page build on this — they differ only in the lead buttons.
  */
 export function useDepositRoute(kind: DepositRouteKind) {
-  const { chainType } = useOpenfortCore()
   const ethWallet = useEthereumEmbeddedWallet()
   const solWallet = useSolanaEmbeddedWallet()
-  // Funds land in the active chain's embedded wallet (EVM or Solana).
-  const wallet = chainType === ChainTypeEnum.SVM ? solWallet : ethWallet
   const { session, status, error, loading, isAvailable, fund, payLink, reset } = useFunding()
   const { chains: allChains, loading: chainsLoading } = useFundingChains()
   const target = useFundingTarget()
-  // Drop the destination chain — funding is cross-chain; same-chain is a plain
-  // transfer with no Relay route, so it shouldn't appear as a source option.
-  const sourceChains = allChains.filter((c) => c.id !== target.chain)
+  // The deposit recipient must live on the TARGET chain, so resolve the wallet by
+  // the target's family — not the active chainType, which can disagree with the
+  // target (e.g. an EVM session whose funding target is still Solana) and would
+  // send an EVM address as the recipient for a Solana destination.
+  const wallet = isSolana(target.chain) ? solWallet : ethWallet
+  // Source chains: the full Relay list, including the destination chain itself so
+  // same-chain deposits (e.g. Solana → Solana) are offered as a plain transfer to
+  // the wallet address, alongside the cross-chain bridge routes.
+  const sourceChains = allChains
   // The CEX rail rides Coinbase Onramp, which only delivers to a fixed set of EVM
   // chains — offer those as the pay-with sources.
   const chains: FundingChain[] = kind === 'cex' ? sourceChains.filter((c) => isCexDeliverable(c.id)) : sourceChains

--- a/packages/openfort-react/src/components/Pages/Deposit/useDepositRoute.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/useDepositRoute.ts
@@ -42,13 +42,11 @@ export function useDepositRoute(kind: DepositRouteKind) {
   // target (e.g. an EVM session whose funding target is still Solana) and would
   // send an EVM address as the recipient for a Solana destination.
   const wallet = isSolana(target.chain) ? solWallet : ethWallet
-  // Source chains: the full Relay list, including the destination chain itself so
+  // Sources are the full Relay list, including the destination chain itself so
   // same-chain deposits (e.g. Solana → Solana) are offered as a plain transfer to
-  // the wallet address, alongside the cross-chain bridge routes.
-  const sourceChains = allChains
-  // The CEX rail rides Coinbase Onramp, which only delivers to a fixed set of EVM
-  // chains — offer those as the pay-with sources.
-  const chains: FundingChain[] = kind === 'cex' ? sourceChains.filter((c) => isCexDeliverable(c.id)) : sourceChains
+  // the wallet address, alongside the cross-chain bridge routes. The CEX rail rides
+  // Coinbase Onramp, which only delivers to a fixed set of EVM chains.
+  const chains: FundingChain[] = kind === 'cex' ? allChains.filter((c) => isCexDeliverable(c.id)) : allChains
   // Where funds land: the active embedded wallet (the Relay deposit recipient).
   const address = wallet.status === 'connected' ? wallet.address : undefined
 

--- a/packages/openfort-react/src/components/Pages/Deposit/useFundingTarget.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/useFundingTarget.ts
@@ -9,17 +9,15 @@ import { DEST_CHAIN, DEST_CHAIN_SOL, DEST_USDC, DEST_USDC_SOL } from './sources'
  * The destination route Deposit-hub funding settles into. Integrators override the
  * chain and currency via `uiConfig.funding.{targetChain,targetCurrency}`; both
  * default to USDC on the active chain type (Base for EVM, Solana mainnet for SVM)
- * so the flow works with zero configuration. `address` is the optional integrator
- * override (`uiConfig.funding.targetAddress`); when unset, callers fall back to the
- * active embedded wallet for the destination chain family.
+ * so the flow works with zero configuration. The deposit recipient is always the
+ * active embedded wallet for the destination chain family — callers resolve it.
  */
-export function useFundingTarget(): { chain: string; currency: string; address?: string } {
+export function useFundingTarget(): { chain: string; currency: string } {
   const { uiConfig } = useOpenfort()
   const { chainType } = useOpenfortCore()
   const isSolana = chainType === ChainTypeEnum.SVM
   return {
     chain: uiConfig.funding?.targetChain ?? (isSolana ? DEST_CHAIN_SOL : DEST_CHAIN),
     currency: uiConfig.funding?.targetCurrency ?? (isSolana ? DEST_USDC_SOL : DEST_USDC),
-    address: uiConfig.funding?.targetAddress,
   }
 }

--- a/packages/openfort-react/src/components/Pages/DepositCex/index.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositCex/index.tsx
@@ -19,7 +19,7 @@ import { CEX_CHAIN_NAMES, isCexDeliverable } from '../Deposit/cexChains'
 import { DepositProgress, isDepositFlowActive } from '../Deposit/DepositProgress'
 import { DepositStatus } from '../Deposit/DepositStatus'
 import { walletListBtn } from '../Deposit/formStyles'
-import { DEST_USDC } from '../Deposit/sources'
+import { DEST_USDC, isSolana } from '../Deposit/sources'
 import { ButtonLogo, StepDivider } from '../Deposit/styles'
 import { useFundingTarget } from '../Deposit/useFundingTarget'
 import { sanitizeAmountInput, sanitizeForParsing } from '../Send/utils'
@@ -81,9 +81,8 @@ const DepositCex = () => {
   // wallet, Solana targets the Solana (SVM) embedded account — never cross families
   // (an EVM address on a Solana target would be rejected / mis-delivered). Accounts
   // come from the core store so EVM-only apps don't need the Solana React context.
-  const isEvmTarget = target.chain.startsWith('eip155:')
   const solanaAddress = embeddedAccounts?.find((acc) => acc.chainType === ChainTypeEnum.SVM)?.address
-  const address = isEvmTarget ? wallet.address : solanaAddress
+  const address = isSolana(target.chain) ? solanaAddress : wallet.address
   const chainSupported = isCexDeliverable(target.chain)
 
   // Resolve the destination asset + chain for the "Arrives as …" line. The live

--- a/packages/openfort-react/src/components/Pages/DepositWallet/DepositWalletDesktop.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositWallet/DepositWalletDesktop.tsx
@@ -35,6 +35,9 @@ type Props = {
   activeChain: FundingChain | undefined
   activeCurrency: FundingCurrency | undefined
   loading: boolean
+  /** Amount to send, in the source token's units. Owned by the parent so the
+   * amount input + presets are shared with the mobile (deeplink) path. */
+  amount: string
 }
 
 /** Readable message from a wallet/provider error; null for a user rejection (4001). */
@@ -47,24 +50,6 @@ function walletErrorMessage(e: unknown): string | null {
   return typeof e === 'string' ? e : 'Transaction failed'
 }
 
-/** Keep only digits and a single decimal point. */
-function sanitizeAmount(v: string): string {
-  const cleaned = v.replace(/[^0-9.]/g, '')
-  const [whole, ...rest] = cleaned.split('.')
-  return rest.length ? `${whole}.${rest.join('')}` : cleaned
-}
-
-const inputStyle: React.CSSProperties = {
-  width: '100%',
-  padding: '12px 14px',
-  borderRadius: 12,
-  border: '1px solid var(--ck-body-divider, #e4e4e7)',
-  background: 'var(--ck-body-background-secondary, #fafafa)',
-  color: 'var(--ck-body-color, #111)',
-  fontSize: 16,
-  outline: 'none',
-}
-
 /**
  * Desktop "transfer from wallet": send the source token to the Relay deposit
  * address straight from the user's EXTERNAL browser-extension wallet
@@ -72,9 +57,8 @@ const inputStyle: React.CSSProperties = {
  * Openfort embedded account (that one is the destination, not the source).
  * Once the deposit lands, the funding session's status polling drives progress.
  */
-export function DepositWalletDesktop({ receiverAddress, activeChain, activeCurrency, loading }: Props) {
+export function DepositWalletDesktop({ receiverAddress, activeChain, activeCurrency, loading, amount }: Props) {
   const bridge = useEthereumBridge()
-  const [amount, setAmount] = useState('')
   const [busyId, setBusyId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [sent, setSent] = useState(false)
@@ -151,14 +135,6 @@ export function DepositWalletDesktop({ receiverAddress, activeChain, activeCurre
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginTop: 14 }}>
-      <input
-        value={amount}
-        onChange={(e) => setAmount(sanitizeAmount(e.target.value))}
-        placeholder={`Amount${activeCurrency ? ` in ${activeCurrency.symbol}` : ''}`}
-        inputMode="decimal"
-        style={inputStyle}
-      />
-
       {connectors.length === 0 && <ModalBody>No browser wallet detected. Install MetaMask or Rabby.</ModalBody>}
 
       {connectors.map((c) => (

--- a/packages/openfort-react/src/components/Pages/DepositWallet/DepositWalletDesktop.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositWallet/DepositWalletDesktop.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ReactNode } from 'react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { type Address, type EIP1193Provider, encodeFunctionData, erc20Abi, formatUnits, parseUnits } from 'viem'
 import { WalletIcon } from '../../../assets/icons'
 import logos from '../../../assets/logos'
@@ -11,6 +11,7 @@ import {
 } from '../../../ethereum/OpenfortEthereumBridgeContext'
 import type { FundingChain, FundingCurrency } from '../../../hooks/openfort/useFundingChains'
 import { ModalBody } from '../../Common/Modal/styles'
+import { useOpenfort } from '../../Openfort/useOpenfort'
 import { DepositStatus } from '../Deposit/DepositStatus'
 import { walletListBtn } from '../Deposit/formStyles'
 import { ButtonLogo } from '../Deposit/styles'
@@ -59,9 +60,17 @@ function walletErrorMessage(e: unknown): string | null {
  */
 export function DepositWalletDesktop({ receiverAddress, activeChain, activeCurrency, loading, amount }: Props) {
   const bridge = useEthereumBridge()
+  const { triggerResize } = useOpenfort()
   const [busyId, setBusyId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [sent, setSent] = useState(false)
+
+  // Grow the modal when the busy / error / sent feedback toggles, so the "Confirm
+  // in your wallet…" and insufficient-balance messages are revealed instead of
+  // clipped below the fold (which reads as "nothing happened" after a click).
+  useEffect(() => {
+    triggerResize()
+  }, [busyId, error, sent, triggerResize])
 
   if (!bridge) return null // EVM-only (no wagmi) — nothing to send through
 

--- a/packages/openfort-react/src/components/Pages/DepositWallet/index.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositWallet/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ReactNode } from 'react'
+import type { ChangeEvent, ReactNode } from 'react'
 import { useEffect, useState } from 'react'
 import { parseUnits } from 'viem'
 import logos from '../../../assets/logos'
@@ -10,12 +10,14 @@ import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
 import { routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
+import { AmountCard, AmountInput, CurrencySymbol, PresetButton, PresetList, Section, SectionLabel } from '../Buy/styles'
 import { AddressPageLink } from '../Deposit/AddressPageLink'
 import { DepositProgress, isDepositFlowActive } from '../Deposit/DepositProgress'
 import { walletListBtn } from '../Deposit/formStyles'
 import { RouteSelectors } from '../Deposit/RouteSelectors'
 import { ButtonLogo, Skeleton, StepDivider } from '../Deposit/styles'
 import { useDepositRoute } from '../Deposit/useDepositRoute'
+import { sanitizeAmountInput } from '../Send/utils'
 import { DepositWalletDesktop } from './DepositWalletDesktop'
 import {
   buildDepositPageUrl,
@@ -35,41 +37,39 @@ const WALLET_LOGO: Record<string, ReactNode> = {
   rabby: <logos.Rabby />,
 }
 
-const amountInputStyle: React.CSSProperties = {
-  width: '100%',
-  padding: '12px 14px',
-  borderRadius: 12,
-  border: '1px solid var(--ck-body-divider, #e4e4e7)',
-  background: 'var(--ck-body-background-secondary, #fafafa)',
-  color: 'var(--ck-body-color, #111)',
-  fontSize: 16,
-  outline: 'none',
-  marginTop: 14,
-}
-
-/** Keep only digits and a single decimal point. */
-function sanitizeAmount(v: string): string {
-  const cleaned = v.replace(/[^0-9.]/g, '')
-  const [whole, ...rest] = cleaned.split('.')
-  return rest.length ? `${whole}.${rest.join('')}` : cleaned
-}
+/** Preset deposit amounts, in the selected source token's units. */
+const PRESETS = [10, 25, 50]
 
 /**
- * Transfer from wallet. On mobile, leads with open-dApp deeplinks that send the
- * user into their wallet app's in-app browser pointed at the hosted deposit page
- * (with the address/chain/token/amount prefilled). On desktop, sends straight
- * from the browser-extension wallet. Either way the manual deposit-address / QR
- * path stays available below.
+ * Transfer from wallet. Pick a source chain/token and an amount, then choose the
+ * wallet to send from. On mobile that's open-dApp deeplinks into the wallet app's
+ * in-app browser (address/chain/token/amount prefilled); on desktop it's a direct
+ * send from a browser-extension wallet. The manual deposit-address / QR path stays
+ * available below.
  */
 const DepositWallet = () => {
   const { triggerResize, uiConfig } = useOpenfort()
   const isMobile = useIsMobile()
   const route = useDepositRoute('crypto')
   const [amount, setAmount] = useState('')
+  const [pressedPreset, setPressedPreset] = useState<number | null>(null)
 
   const depositPageUrl = uiConfig.funding?.depositPageUrl ?? OPENFORT_DEPOSIT_PAGE_URL
   const srcChainId = caipToChainId(route.activeChain?.id)
   const amountValid = Number.parseFloat(amount) > 0
+
+  const handleAmountChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const raw = sanitizeAmountInput(event.target.value)
+    if (raw === '' || /^[0-9]*\.?[0-9]*$/.test(raw)) {
+      setPressedPreset(null)
+      setAmount(raw)
+    }
+  }
+
+  const handlePreset = (value: number) => {
+    setPressedPreset(value)
+    setAmount(String(value))
+  }
 
   // Open-dApp deeplinks: prefer backend-provided ones; otherwise build them from
   // the hosted deposit page URL (if the integrator configured one) carrying the
@@ -118,18 +118,36 @@ const DepositWallet = () => {
 
       {!route.isAvailable && <ModalBody>Funding isn't available right now.</ModalBody>}
 
-      <StepDivider>{isMobile ? 'Then open your wallet' : 'Then send from your wallet'}</StepDivider>
+      <Section>
+        <SectionLabel>Amount</SectionLabel>
+        <AmountCard>
+          <CurrencySymbol>{route.activeCurrency?.symbol ?? ''}</CurrencySymbol>
+          <AmountInput
+            value={amount}
+            onChange={handleAmountChange}
+            placeholder="0.00"
+            inputMode="decimal"
+            autoComplete="off"
+          />
+        </AmountCard>
+        <PresetList>
+          {PRESETS.map((preset) => (
+            <PresetButton
+              key={preset}
+              type="button"
+              $active={pressedPreset === preset}
+              onClick={() => handlePreset(preset)}
+            >
+              {preset}
+            </PresetButton>
+          ))}
+        </PresetList>
+      </Section>
+
+      <StepDivider>Then select the wallet you want to use</StepDivider>
 
       {isMobile ? (
         <>
-          <input
-            value={amount}
-            onChange={(e) => setAmount(sanitizeAmount(e.target.value))}
-            placeholder={`Amount${route.activeCurrency ? ` in ${route.activeCurrency.symbol}` : ''}`}
-            inputMode="decimal"
-            style={amountInputStyle}
-          />
-
           {!depositPageUrl && (
             <ModalBody style={{ marginTop: 12 }}>Use a deposit address below to fund from your wallet.</ModalBody>
           )}
@@ -174,6 +192,7 @@ const DepositWallet = () => {
           activeChain={route.activeChain}
           activeCurrency={route.activeCurrency}
           loading={route.loading}
+          amount={amount}
         />
       )}
 

--- a/packages/openfort-react/src/components/Pages/DepositWallet/index.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositWallet/index.tsx
@@ -15,6 +15,7 @@ import { AddressPageLink } from '../Deposit/AddressPageLink'
 import { DepositProgress, isDepositFlowActive } from '../Deposit/DepositProgress'
 import { walletListBtn } from '../Deposit/formStyles'
 import { RouteSelectors } from '../Deposit/RouteSelectors'
+import { isSolana } from '../Deposit/sources'
 import { ButtonLogo, Skeleton, StepDivider } from '../Deposit/styles'
 import { useDepositRoute } from '../Deposit/useDepositRoute'
 import { sanitizeAmountInput } from '../Send/utils'
@@ -55,6 +56,10 @@ const DepositWallet = () => {
   const [pressedPreset, setPressedPreset] = useState<number | null>(null)
 
   const depositPageUrl = uiConfig.funding?.depositPageUrl ?? OPENFORT_DEPOSIT_PAGE_URL
+  // Solana sources have no numeric chain id and no desktop EVM-extension send, so
+  // they route through the deeplink (Phantom) on every platform instead of the
+  // wagmi-bridge desktop path.
+  const isSolanaSrc = isSolana(route.activeChain?.id ?? '')
   const srcChainId = caipToChainId(route.activeChain?.id)
   const amountValid = Number.parseFloat(amount) > 0
 
@@ -76,10 +81,11 @@ const DepositWallet = () => {
   // resolved transfer params. The hosted page sends via the wallet's injected
   // provider, so no backend wiring is required for the link itself.
   const pageUrl =
-    depositPageUrl && route.receiverAddress && route.activeCurrency && srcChainId
+    depositPageUrl && route.receiverAddress && route.activeCurrency && (isSolanaSrc || srcChainId)
       ? buildDepositPageUrl(depositPageUrl, {
+          vm: isSolanaSrc ? 'svm' : 'evm',
           to: route.receiverAddress,
-          chainId: srcChainId,
+          chainId: isSolanaSrc ? undefined : srcChainId,
           token: route.activeCurrency.native ? undefined : route.activeCurrency.address,
           decimals: route.activeCurrency.decimals,
           symbol: route.activeCurrency.symbol,
@@ -146,7 +152,7 @@ const DepositWallet = () => {
 
       <StepDivider>Then select the wallet you want to use</StepDivider>
 
-      {isMobile ? (
+      {isMobile || isSolanaSrc ? (
         <>
           {!depositPageUrl && (
             <ModalBody style={{ marginTop: 12 }}>Use a deposit address below to fund from your wallet.</ModalBody>

--- a/packages/openfort-react/src/components/Pages/DepositWallet/walletDeeplinks.test.ts
+++ b/packages/openfort-react/src/components/Pages/DepositWallet/walletDeeplinks.test.ts
@@ -3,6 +3,7 @@ import { buildDepositPageUrl, buildOpenDappLinks, caipToChainId } from './wallet
 
 const PAGE = 'https://app.example.com/deposit.html'
 const PARAMS = {
+  vm: 'evm' as const,
   to: '0xCb1cC9ddb3FF9532F9cF6cf7365327EeA52d68b3',
   chainId: 42161,
   token: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
@@ -27,12 +28,30 @@ describe('buildDepositPageUrl', () => {
   it('encodes the transfer params as query string', () => {
     const url = new URL(buildDepositPageUrl(PAGE, PARAMS))
     expect(url.origin + url.pathname).toBe(PAGE)
+    expect(url.searchParams.get('vm')).toBe('evm')
     expect(url.searchParams.get('to')).toBe(PARAMS.to)
     expect(url.searchParams.get('chainId')).toBe('42161')
     expect(url.searchParams.get('token')).toBe(PARAMS.token)
     expect(url.searchParams.get('decimals')).toBe('6')
     expect(url.searchParams.get('symbol')).toBe('USDC')
     expect(url.searchParams.get('chain')).toBe('Arbitrum')
+  })
+
+  it('builds a Solana (svm) request with no numeric chainId', () => {
+    const url = new URL(
+      buildDepositPageUrl(PAGE, {
+        vm: 'svm',
+        to: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        token: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        decimals: 6,
+        symbol: 'USDC',
+        chain: 'Solana',
+      })
+    )
+    expect(url.searchParams.get('vm')).toBe('svm')
+    expect(url.searchParams.has('chainId')).toBe(false)
+    expect(url.searchParams.get('to')).toBe('5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp')
+    expect(url.searchParams.get('token')).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
   })
 
   it('omits token for a native asset and amount when not given', () => {

--- a/packages/openfort-react/src/components/Pages/DepositWallet/walletDeeplinks.ts
+++ b/packages/openfort-react/src/components/Pages/DepositWallet/walletDeeplinks.ts
@@ -23,11 +23,13 @@ export type VmType = 'evm' | 'svm'
 export const OPENFORT_DEPOSIT_PAGE_URL = 'https://deposit.openfort.io'
 
 type DepositPageParams = {
-  /** Relay deposit address the source funds go to. */
+  /** Source VM family. `evm` drives a window.ethereum send; `svm` a Solana Pay request. */
+  vm: VmType
+  /** Relay deposit address the source funds go to (0x for EVM, base58 for Solana). */
   to: string
-  /** Numeric source chain id (e.g. 42161). */
-  chainId: number
-  /** ERC-20 contract, or empty/undefined for the chain's native token. */
+  /** Numeric source chain id (e.g. 42161). EVM only. */
+  chainId?: number
+  /** ERC-20 contract / SPL mint, or empty/undefined for the chain's native token. */
   token?: string
   decimals: number
   symbol: string
@@ -40,8 +42,9 @@ type DepositPageParams = {
 /** Build the deposit "send" page URL with the transfer params encoded. */
 export function buildDepositPageUrl(baseUrl: string, p: DepositPageParams): string {
   const url = new URL(baseUrl)
+  url.searchParams.set('vm', p.vm)
   url.searchParams.set('to', p.to)
-  url.searchParams.set('chainId', String(p.chainId))
+  if (p.vm === 'evm' && p.chainId !== undefined) url.searchParams.set('chainId', String(p.chainId))
   if (p.token) url.searchParams.set('token', p.token)
   url.searchParams.set('decimals', String(p.decimals))
   url.searchParams.set('symbol', p.symbol)

--- a/packages/openfort-react/src/components/Pages/SelectToken/index.tsx
+++ b/packages/openfort-react/src/components/Pages/SelectToken/index.tsx
@@ -9,6 +9,7 @@ import { Arrow, ArrowChevron, TextLinkButton } from '../../Common/Button/styles'
 import { ModalHeading } from '../../Common/Modal/styles'
 import { type Asset, routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
+import { EVM_BUY_CURRENCIES } from '../Buy/evmCurrencies'
 import { SOLANA_BUY_CURRENCIES } from '../Buy/solanaCurrencies'
 import { formatBalanceWithSymbol, getAssetDecimals, getAssetSymbol } from '../Send/utils'
 import {
@@ -42,9 +43,14 @@ const SelectToken = ({ isBuyFlow }: { isBuyFlow: boolean }) => {
   const { chainType } = useOpenfortCore()
   const { data: walletAssets, isLoading: isBalancesLoading } = useEthereumWalletAssets()
 
-  // Solana buys pick from a fixed currency list (USDC, SOL); everything else reads
-  // the EVM wallet's assets. (Solana send doesn't use this picker.)
-  const selectableTokens = isBuyFlow && chainType === ChainTypeEnum.SVM ? SOLANA_BUY_CURRENCIES : walletAssets || []
+  // Buys pick from a fixed buyable-currency list (USDC first, then native) per
+  // chain family, so the picker always has options even for a fresh wallet with no
+  // indexed balances. The send flow reads the EVM wallet's actual assets.
+  const selectableTokens = isBuyFlow
+    ? chainType === ChainTypeEnum.SVM
+      ? SOLANA_BUY_CURRENCIES
+      : EVM_BUY_CURRENCIES
+    : walletAssets || []
 
   const handleSelect = (asset: Asset) => {
     // In send flow, don't allow selecting tokens with 0 balance

--- a/packages/openfort-react/src/hooks/openfort/useFunding.ts
+++ b/packages/openfort-react/src/hooks/openfort/useFunding.ts
@@ -219,11 +219,11 @@ export type UseFundingOptions = {
 export function useFunding(options?: UseFundingOptions): UseFunding {
   const { uiConfig, publishableKey } = useOpenfort()
   const { client: coreClient } = useOpenfortCore()
-  // The CEX rail (DepositCex) is served by the Openfort API; everything else uses
-  // the standalone funding service at uiConfig.fundingBaseUrl.
-  const baseUrl = options?.useBackendUrl
-    ? SDKConfiguration.getInstance()?.backendUrl || 'https://api.openfort.io'
-    : (uiConfig.fundingBaseUrl ?? '')
+  // The funding JSON API defaults to the Openfort backend (api.openfort.io);
+  // integrators can point the crypto rails at a custom service via
+  // uiConfig.fundingBaseUrl. The CEX rail always uses the backend (Coinbase pay-link).
+  const backendUrl = SDKConfiguration.getInstance()?.backendUrl || 'https://api.openfort.io'
+  const baseUrl = options?.useBackendUrl ? backendUrl : uiConfig.fundingBaseUrl || backendUrl
   const injected = options?.client
   // Resolve the client, in order of preference:
   //   1. an explicitly injected client (tests / custom backends),

--- a/packages/openfort-react/src/hooks/openfort/useFundingChains.ts
+++ b/packages/openfort-react/src/hooks/openfort/useFundingChains.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { SDKConfiguration } from '@openfort/openfort-js'
 import { useEffect, useState } from 'react'
 import { useOpenfort } from '../../components/Openfort/useOpenfort'
 
@@ -63,16 +64,13 @@ const DEFAULT_SOURCE_CURRENCIES = ['native', 'USDC', 'USDT']
  */
 export function useFundingChains(): UseFundingChains {
   const { uiConfig } = useOpenfort()
-  const baseUrl = uiConfig.fundingBaseUrl ?? ''
+  // Defaults to the SDK backend (api.openfort.io); override for a custom funding service.
+  const baseUrl = uiConfig.fundingBaseUrl || SDKConfiguration.getInstance()?.backendUrl || 'https://api.openfort.io'
   const sourceChains = uiConfig.funding?.sourceChains ?? DEFAULT_SOURCE_CHAINS
   const sourceCurrencies = uiConfig.funding?.sourceCurrencies ?? DEFAULT_SOURCE_CURRENCIES
-  const [state, setState] = useState<UseFundingChains>({ chains: [], loading: Boolean(baseUrl), error: null })
+  const [state, setState] = useState<UseFundingChains>({ chains: [], loading: true, error: null })
 
   useEffect(() => {
-    if (!baseUrl) {
-      setState({ chains: [], loading: false, error: null })
-      return
-    }
     let cancelled = false
     setState((s) => ({ ...s, loading: true }))
     fetch(`${baseUrl}/v2/funding/chains`)


### PR DESCRIPTION
## What

Deposit hub fixes, in two waves.

### Wave 1 — base URL + dead override
- **Default `fundingBaseUrl` to `https://api.openfort.io`.** The Deposit hub loads source chains (`GET /v2/funding/chains`) and creates sessions against `uiConfig.fundingBaseUrl`. The playground defaulted it to `https://funding.openfort.io`, which no longer resolves (DNS NXDOMAIN) — so no source chains loaded, the QR never rendered, and nothing reached Relay. `deposit.openfort.io` (the hosted Deposit page, `depositPageUrl`) is separate and unchanged.
- **Remove the dead `uiConfig.funding.targetAddress` override.** Deposits always settle into the active embedded wallet, the address sent to Relay as the recipient. `main` already dropped the override from `useDepositRoute`/`DepositCex`; this removes the remnants in `FundingUIOptions`, `useFundingTarget`, and the playground syncs.

### Wave 2 — review fixes
- **Resolve the deposit recipient by the funding target's chain family**, not the active chainType. A target/wallet mismatch (EVM session, stale Solana target) sent an EVM address as the recipient for a Solana destination — Relay rejected it ("Invalid address … for chain 792703809"). Mirrors `DepositCex`.
- **Offer the destination chain itself as a source**, so same-chain deposits (e.g. Solana → Solana) show as a plain transfer to the wallet address, alongside cross-chain routes. Solana added to the playground source list; the playground falls back to Base USDC on EVM testnets so it never keeps a stale Solana target.
- **Default the card / Apple Pay buy to USDC on EVM** (matching Solana). The picker lists buyable currencies (USDC, native) instead of the wallet's indexed balances, so a fresh wallet no longer shows "No supported tokens found".
- **Subtitles:** "Bridge fee" (was "No fee") for wallet/address; $5 minimum for the exchange rail.

## Verify
- biome (525 files), `tsc --noEmit`, `@openfort/react` tests (203) — all green.
- Localhost (playground, guest wallet): subtitles correct; "Transfer from address" resolves a deposit address with no route error; Solana present in the source list; card buy defaults to USDC with a populated asset list.

## Backend follow-up (not in this PR)
Solana deposit-address routes (any cross-VM bridge into/out of Solana) need `RELAY_API_KEY` set on `api.openfort.io`. Without it the rail returns `400 "missing an api key and cannot use a deposit address"`. Same-chain Solana → Solana is unaffected (it mints no Relay address).

🤖 Generated with [Claude Code](https://claude.com/claude-code)