### PR TITLE
fix(funding): show EVM-source wallets in Solana-only mode

### DIFF
--- a/.changeset/funding-svm-evm-source-wallets.md
+++ b/.changeset/funding-svm-evm-source-wallets.md
@@ -1,0 +1,5 @@
+---
+'@openfort/react': patch
+---
+
+Fix the empty wallet list in "Transfer from wallet" for EVM sources when the active wallet is Solana-only. In Solana mode there's no wagmi bridge, so the desktop browser-extension send (`DepositWalletDesktop`) renders nothing — no wallet was offered for an EVM source. The hub now falls back to the open-dApp deeplinks (MetaMask, Phantom, …) whenever the wagmi bridge is absent, matching the mobile and same-chain Solana paths.

--- a/packages/openfort-react/src/components/Pages/DepositWallet/index.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositWallet/index.tsx
@@ -4,6 +4,7 @@ import type { ChangeEvent, ReactNode } from 'react'
 import { useEffect, useState } from 'react'
 import { parseUnits } from 'viem'
 import logos from '../../../assets/logos'
+import { useEthereumBridge } from '../../../ethereum/OpenfortEthereumBridgeContext'
 import useIsMobile from '../../../hooks/useIsMobile'
 import { isIOS } from '../../../utils'
 import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
@@ -52,6 +53,10 @@ const DepositWallet = () => {
   const { triggerResize, uiConfig } = useOpenfort()
   const isMobile = useIsMobile()
   const route = useDepositRoute('crypto')
+  // The desktop send path goes through the wagmi bridge (browser-extension wallets).
+  // In Solana-only mode there's no wagmi provider, so fall back to the open-dApp
+  // deeplinks for EVM sources too — otherwise the wallet list renders empty.
+  const bridge = useEthereumBridge()
   const [amount, setAmount] = useState('')
   const [pressedPreset, setPressedPreset] = useState<number | null>(null)
 
@@ -152,7 +157,7 @@ const DepositWallet = () => {
 
       <StepDivider>Then select the wallet you want to use</StepDivider>
 
-      {isMobile || isSolanaSrc ? (
+      {isMobile || isSolanaSrc || !bridge ? (
         <>
           {!depositPageUrl && (
             <ModalBody style={{ marginTop: 12 }}>Use a deposit address below to fund from your wallet.</ModalBody>


### PR DESCRIPTION
## What

In Solana-only mode (`OpenfortProvider` with no wagmi), the Deposit hub's "Transfer from wallet" rail showed **no wallet** when an EVM source chain was selected. The desktop send (`DepositWalletDesktop`) goes through the wagmi bridge, which doesn't exist in Solana-only mode, so it rendered `null`. Same-chain Solana worked (it uses the deeplink path), which is why Phantom appeared there but nothing appeared for EVM sources.

Fix: fall back to the open-dApp deeplinks (MetaMask, Phantom, …) whenever the wagmi bridge is absent — `isMobile || isSolanaSrc || !bridge`. The deposit-address path remains available below.

## Verify
- biome / tsc / `@openfort/react` tests (209) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)