### PR TITLE
feat(funding): testnet funding support

### DIFF
--- a/.changeset/funding-testnet-support.md
+++ b/.changeset/funding-testnet-support.md
@@ -1,0 +1,8 @@
+---
+"@openfort/react": minor
+---
+
+Add testnet funding support: the deposit flow now uses Relay's testnet rail for
+`pk_test_…` keys (native ETH on Base Sepolia / Sepolia), explains testnet limits,
+disables unsupported rails, detects same-chain arrivals, and shows testnet native
+balances. Also fixes chain/currency logos and the explorer link.

--- a/examples/playground/src/lib/chains.ts
+++ b/examples/playground/src/lib/chains.ts
@@ -65,6 +65,40 @@ export function getEvmChainsForKey(publishableKey?: string): PlaygroundEvmChain[
   return filtered.length > 0 ? filtered : PLAYGROUND_EVM_CHAINS
 }
 
+/** Native-asset sentinel: the zero address denotes a chain's native currency (ETH, …). */
+const NATIVE_CURRENCY = '0x0000000000000000000000000000000000000000'
+
+/**
+ * Deposit-hub SOURCE config (the chains + currencies a user can fund FROM), matched
+ * to the publishable key environment. The funding TARGET is deliberately NOT set
+ * here — it's owned solely by {@link FundingTargetSync}, which follows the active
+ * chain via {@link getFundingTargetForChain}. Test keys use Relay's testnet rail
+ * (Base Sepolia / Sepolia; native ETH only, since testnets have no DEX liquidity to
+ * swap into a stablecoin); live keys expose the major mainnet sources.
+ */
+export function getFundingConfigForKey(publishableKey?: string): {
+  sourceChains: string[]
+  sourceCurrencies: string[]
+} {
+  if (publishableKey?.startsWith('pk_test_')) {
+    return {
+      sourceChains: ['eip155:84532', 'eip155:11155111'], // Base Sepolia, Sepolia
+      sourceCurrencies: ['native'], // ETH only — testnet swaps have no liquidity
+    }
+  }
+  return {
+    sourceChains: [
+      'eip155:42161',
+      'eip155:8453',
+      'eip155:10',
+      'eip155:137',
+      'eip155:1',
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+    ],
+    sourceCurrencies: ['ETH', 'USDC', 'USDT', 'DAI'],
+  }
+}
+
 export const DEFAULT_EVM_CHAIN = PLAYGROUND_EVM_CHAINS.find((c) => c.id === baseSepolia.id)!
 
 export const EVM_CHAIN_BY_ID: Record<number, PlaygroundEvmChain> = Object.fromEntries(
@@ -74,15 +108,22 @@ export const EVM_CHAIN_BY_ID: Record<number, PlaygroundEvmChain> = Object.fromEn
 export const RPC_URLS: Record<number, string> = Object.fromEntries(PLAYGROUND_EVM_CHAINS.map((c) => [c.id, c.rpcUrl]))
 
 /**
- * Deposit-hub funding target (CAIP-2 chain + USDC address) for an active chain.
- * Returns undefined for chains without a configured USDC (e.g. testnets), so the
- * caller keeps the previous target instead of routing to an unsupported chain.
+ * Deposit-hub funding target (CAIP-2 chain + currency) for an active chain.
+ *
+ * Mainnet chains fund their USDC. Testnet chains fund their NATIVE asset (ETH):
+ * Relay's testnet rail bridges same-asset but has no DEX liquidity to swap into a
+ * stablecoin, so a USDC target would fail — native ETH is the route that works.
+ * Returns undefined only for unknown chains (caller falls back).
  */
 export function getFundingTargetForChain(
   chainId?: number
 ): { targetChain: string; targetCurrency: string } | undefined {
   const chain = chainId != null ? EVM_CHAIN_BY_ID[chainId] : undefined
-  if (!chain?.usdc) return undefined
+  if (!chain) return undefined
+  if (chain.viemChain.testnet) {
+    return { targetChain: `eip155:${chain.id}`, targetCurrency: NATIVE_CURRENCY }
+  }
+  if (!chain.usdc) return undefined
   return { targetChain: `eip155:${chain.id}`, targetCurrency: chain.usdc }
 }
 

--- a/examples/playground/src/lib/useAppStore.ts
+++ b/examples/playground/src/lib/useAppStore.ts
@@ -7,7 +7,14 @@ import {
 } from '@openfort/react'
 import { base, polygonAmoy } from 'viem/chains'
 import { create } from 'zustand'
-import { DEFAULT_EVM_CHAIN, PLAYGROUND_EVM_CHAINS, RPC_URLS, SOLANA_CLUSTER, SOLANA_DEFAULT_RPC } from '@/lib/chains'
+import {
+  DEFAULT_EVM_CHAIN,
+  getFundingConfigForKey,
+  PLAYGROUND_EVM_CHAINS,
+  RPC_URLS,
+  SOLANA_CLUSTER,
+  SOLANA_DEFAULT_RPC,
+} from '@/lib/chains'
 
 const defaultWalletConfig: OpenfortWalletConfig = {
   shieldPublishableKey: import.meta.env.VITE_SHIELD_PUBLISHABLE_KEY,
@@ -64,21 +71,11 @@ const defaultProviderOptions: Parameters<typeof OpenfortProvider>[0] = {
     // sentinel) so only Relay-supported deposit-address tokens show — e.g. ETH is
     // routable but Polygon's POL isn't ("major tokens" only). ETH uses a 0.01-unit
     // mint nominal so it isn't 1 whole ETH (see nominalUnits).
-    funding: {
-      sourceChains: [
-        'eip155:42161',
-        'eip155:8453',
-        'eip155:10',
-        'eip155:137',
-        'eip155:1',
-        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-      ],
-      sourceCurrencies: ['ETH', 'USDC', 'USDT', 'DAI'],
-      targetChain: 'eip155:8453',
-      targetCurrency: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-      // depositPageUrl omitted → uses the SDK default (https://deposit.openfort.io),
-      // the zero-config path a real integrator gets.
-    },
+    // Funding SOURCE chains/currencies matched to the key environment (testnet vs
+    // mainnet). The funding TARGET is owned by FundingTargetSync, which follows the
+    // active chain — not set here. depositPageUrl omitted → SDK default
+    // (https://deposit.openfort.io), the zero-config path a real integrator gets.
+    funding: getFundingConfigForKey(import.meta.env.VITE_OPENFORT_PUBLISHABLE_KEY),
     theme: 'auto',
     mode: undefined,
     customTheme: undefined,

--- a/examples/playground/src/providers.tsx
+++ b/examples/playground/src/providers.tsx
@@ -114,11 +114,12 @@ const MODE_TO_CHAIN = { evm: ChainTypeEnum.EVM, svm: ChainTypeEnum.SVM } as cons
 
 /**
  * Keeps the Deposit-hub funding target in sync with the active EVM chain, so
- * switching networks in the OpenfortButton lands deposits on that chain's USDC.
- * Chains without a configured USDC (testnets) fall back to Base USDC, so EVM mode
- * never keeps a stale Solana target from a prior SVM session (which would make the
- * EVM recipient invalid for the Solana destination). Deposits land on the active
- * EVM embedded wallet, resolved by the Deposit hub.
+ * switching networks in the OpenfortButton lands deposits on that chain. Mainnet
+ * chains target their USDC; testnet chains target native ETH (Relay's testnet rail
+ * bridges same-asset but can't swap into a stablecoin — see getFundingTargetForChain).
+ * Unknown chains fall back to Base USDC, so EVM mode never keeps a stale Solana
+ * target from a prior SVM session (which would make the EVM recipient invalid for
+ * the Solana destination). Deposits land on the active EVM embedded wallet.
  */
 function FundingTargetSync() {
   const chainId = useChainId()

--- a/packages/openfort-react/src/__tests__/useDepositRoute.test.ts
+++ b/packages/openfort-react/src/__tests__/useDepositRoute.test.ts
@@ -32,7 +32,7 @@ vi.mock('../hooks/openfort/useFunding', () => ({
   }),
 }))
 vi.mock('../hooks/openfort/useFundingChains', () => ({
-  useFundingChains: () => ({ chains: [], loading: false, error: null }),
+  useFundingChains: () => ({ chains: [], railChains: [], loading: false, error: null }),
   nominalUnits: (decimals: number) => `1${'0'.repeat(decimals + 1)}`,
 }))
 vi.mock('../components/Pages/Deposit/useFundingTarget', () => ({

--- a/packages/openfort-react/src/components/ConnectModal/index.tsx
+++ b/packages/openfort-react/src/components/ConnectModal/index.tsx
@@ -174,17 +174,27 @@ const ConnectModal: React.FC<{
   const chainId = strategy?.getChainId()
   const chainIsSupported = chainId != null && context.chains.some((c) => c.id === chainId)
 
-  // Auto-close when the user goes from not-connected → connected while the modal is open.
-  // Using a ref to track the previous value so we only react to the false → true transition,
-  // not when the modal is opened while already connected (e.g. user opens profile).
+  // Auto-close only when the connect/auth flow completes: the modal was opened while
+  // disconnected and then became connected. We latch the "opened-while-connected" state
+  // on each open transition, so a chain switch — which briefly drops and restores the
+  // connection while the modal is already open and connected — never triggers a close.
+  const prevOpenRef = useRef(context.open)
+  const openedConnectedRef = useRef(isConnected)
   const prevIsConnectedRef = useRef(isConnected)
   useEffect(() => {
+    const justOpened = context.open && !prevOpenRef.current
+    prevOpenRef.current = context.open
+    if (justOpened) {
+      openedConnectedRef.current = isConnected
+      prevIsConnectedRef.current = isConnected
+      return
+    }
     const wasConnected = prevIsConnectedRef.current
     prevIsConnectedRef.current = isConnected
-    if (!wasConnected && isConnected && context.open) {
+    if (!openedConnectedRef.current && !wasConnected && isConnected && context.open) {
       context.setOpen(false)
     }
-  }, [isConnected])
+  }, [isConnected, context.open])
 
   //if chain is unsupported we enforce a "switch chain" prompt
   const closeable = !(context.uiConfig.enforceSupportedChains && isConnected && !chainIsSupported)

--- a/packages/openfort-react/src/components/PageContent/index.tsx
+++ b/packages/openfort-react/src/components/PageContent/index.tsx
@@ -15,9 +15,17 @@ type PageContentProps = {
   onBack?: SetOnBackFunction
   logoutOnBack?: boolean
   header?: string
+  className?: string
 }
 
-export const PageContent = ({ children, width, onBack = 'back', logoutOnBack, header }: PageContentProps) => {
+export const PageContent = ({
+  children,
+  width,
+  onBack = 'back',
+  logoutOnBack,
+  header,
+  className,
+}: PageContentProps) => {
   const { setOnBack, setRoute, setPreviousRoute, setRouteHistory } = useOpenfort()
   const { signOut } = useSignOut()
 
@@ -57,7 +65,7 @@ export const PageContent = ({ children, width, onBack = 'back', logoutOnBack, he
   }, [!!onBack, !!logoutOnBack])
 
   return (
-    <PageContentStyle style={{ width }}>
+    <PageContentStyle className={className} style={{ width }}>
       {header && <ModalHeading>{header}</ModalHeading>}
       {children}
     </PageContentStyle>

--- a/packages/openfort-react/src/components/Pages/Connected/EthereumConnected.tsx
+++ b/packages/openfort-react/src/components/Pages/Connected/EthereumConnected.tsx
@@ -83,16 +83,20 @@ const EthereumConnected: React.FC = () => {
   const ensName = identity.status === 'success' ? identity.name : undefined
 
   const { data: assets, isLoading } = useEthereumWalletAssets()
+  // Total is summed from the multi-chain assets so the headline matches the
+  // "Your assets" breakdown. The single-chain path omits fiat for native ETH,
+  // which would otherwise drop it from the total.
+  const { data: multiChainAssets } = useEthereumWalletAssets({ multiChain: true })
   const totalBalanceUsd = useMemo(() => {
-    if (!assets) return 0
-    return assets.reduce((acc, asset) => {
+    if (!multiChainAssets) return 0
+    return multiChainAssets.reduce((acc, asset) => {
       if (!asset.metadata || !asset.balance) return acc
       const price: number = asset.metadata?.fiat?.value ?? 0
       if (!price) return acc
       const balance = Number(formatUnits(asset.balance ?? BigInt(0), getAssetDecimals(asset)))
       return acc + price * balance
     }, 0)
-  }, [assets])
+  }, [multiChainAssets])
 
   useEffect(() => {
     context.triggerResize()

--- a/packages/openfort-react/src/components/Pages/Deposit/AssetChainLogo.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/AssetChainLogo.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import type { SyntheticEvent } from 'react'
+import { type SyntheticEvent, useState } from 'react'
+import { symbolToColor } from '../../../constants/logos'
 
 const hide = (e: SyntheticEvent<HTMLImageElement>) => {
   e.currentTarget.style.display = 'none'
@@ -9,26 +10,65 @@ const hide = (e: SyntheticEvent<HTMLImageElement>) => {
 /**
  * Center logo for the deposit QR: the asset logo with the chain logo as a small
  * badge bottom-left, so scanners can confirm the right token + network at a glance.
- * Kept fully within the logo slot (no overflow) so it never covers QR data modules.
+ * Falls back to a colored monogram when the token has no usable logo, so the QR
+ * centre is never blank (and never collapses to just the chain badge). Kept fully
+ * within the logo slot (no overflow) so it never covers QR data modules.
  */
-export function AssetChainLogo({ assetLogo, chainLogo }: { assetLogo: string; chainLogo: string }) {
+export function AssetChainLogo({
+  assetLogo,
+  chainLogo,
+  symbol,
+}: {
+  assetLogo: string
+  chainLogo: string
+  symbol?: string
+}) {
+  const [assetFailed, setAssetFailed] = useState(false)
+  const showMonogram = !assetLogo || assetFailed
+
   return (
     <div style={{ position: 'relative', width: '100%' }}>
-      <img src={assetLogo} alt="" onError={hide} style={{ display: 'block', width: '100%', borderRadius: '50%' }} />
-      <img
-        src={chainLogo}
-        alt=""
-        onError={hide}
-        style={{
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          width: '42%',
-          borderRadius: '50%',
-          border: '2px solid #fff',
-          background: '#fff',
-        }}
-      />
+      {showMonogram ? (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '100%',
+            aspectRatio: '1 / 1',
+            borderRadius: '50%',
+            background: symbolToColor(symbol || '?'),
+            color: '#fff',
+            fontWeight: 600,
+            fontSize: 28,
+          }}
+        >
+          {(symbol || '?').charAt(0).toUpperCase()}
+        </div>
+      ) : (
+        <img
+          src={assetLogo}
+          alt=""
+          onError={() => setAssetFailed(true)}
+          style={{ display: 'block', width: '100%', borderRadius: '50%' }}
+        />
+      )}
+      {chainLogo && (
+        <img
+          src={chainLogo}
+          alt=""
+          onError={hide}
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            width: '42%',
+            borderRadius: '50%',
+            border: '2px solid #fff',
+            background: '#fff',
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/packages/openfort-react/src/components/Pages/Deposit/DepositAddressBlock.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/DepositAddressBlock.tsx
@@ -55,7 +55,9 @@ export function DepositAddressBlock({
           // Encode the EIP-681 / Solana Pay URI (address + amount + network) so a
           // scanner prefills the send; fall back to the bare address same-chain.
           value={pm?.addressUri ?? receiverAddress}
-          image={<AssetChainLogo assetLogo={assetLogo ?? ''} chainLogo={chainLogo ?? ''} />}
+          image={
+            <AssetChainLogo assetLogo={assetLogo ?? ''} chainLogo={chainLogo ?? ''} symbol={sourceCurrency?.symbol} />
+          }
           imageClip={false}
         />
       </QRWrapper>

--- a/packages/openfort-react/src/components/Pages/Deposit/RouteSelectors.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/RouteSelectors.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import { chainLogoUrl, currencyLogoUrl } from '../../../constants/logos'
 import type { FundingChain } from '../../../hooks/openfort/useFundingChains'
+import { caipToChainId } from '../DepositWallet/walletDeeplinks'
 import { field, twoCol } from './formStyles'
 import { LogoSelect } from './LogoSelect'
 import { Skeleton } from './styles'
@@ -50,7 +52,11 @@ export function RouteSelectors({
         <LogoSelect
           value={activeChain?.id ?? ''}
           onChange={onChainChange}
-          options={chains.map((c) => ({ value: c.id, label: c.name, logo: c.logo }))}
+          options={chains.map((c) => ({
+            value: c.id,
+            label: c.name,
+            logo: chainLogoUrl(caipToChainId(c.id), c.logo),
+          }))}
         />
       </div>
       <div style={field}>
@@ -58,7 +64,11 @@ export function RouteSelectors({
         <LogoSelect
           value={currency}
           onChange={onCurrencyChange}
-          options={currencies.map((c) => ({ value: c.symbol, label: c.symbol, logo: c.logo }))}
+          options={currencies.map((c) => ({
+            value: c.symbol,
+            label: c.symbol,
+            logo: currencyLogoUrl(c.symbol, c.logo),
+          }))}
         />
       </div>
     </div>

--- a/packages/openfort-react/src/components/Pages/Deposit/SameChainDepositStatus.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/SameChainDepositStatus.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useEffect } from 'react'
+import styled from '../../../styles/styled'
+import { Spinner } from '../../Common/Spinner'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+
+const Banner = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--ck-body-divider, #e4e4e7);
+  background: var(--ck-body-background-secondary, #fafafa);
+  font-size: 14px;
+  color: var(--ck-body-color-muted, #6b7280);
+`
+
+/**
+ * "Waiting for your deposit…" banner shown under the deposit address for a
+ * same-chain "transfer from address". Arrival detection lives in
+ * {@link import('./useSameChainArrival').useSameChainArrival}; on arrival the
+ * page swaps to {@link import('./SameChainDepositSuccess').SameChainDepositSuccess}.
+ */
+export function SameChainDepositStatus() {
+  const { triggerResize } = useOpenfort()
+
+  useEffect(() => {
+    triggerResize()
+  }, [triggerResize])
+
+  return (
+    <Banner>
+      <Spinner />
+      <span>Waiting for your deposit…</span>
+    </Banner>
+  )
+}

--- a/packages/openfort-react/src/components/Pages/Deposit/SameChainDepositSuccess.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/SameChainDepositSuccess.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { ChainTypeEnum } from '@openfort/openfort-js'
+import { useEffect } from 'react'
+import { getExplorerUrl } from '../../../shared/utils/explorer'
+import Button from '../../Common/Button'
+import Loader from '../../Common/Loading'
+import PoweredByFooter from '../../Common/PoweredByFooter'
+import { routes } from '../../Openfort/types'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+import { PageContent } from '../../PageContent'
+
+/**
+ * Terminal success screen for a same-chain "transfer from address" deposit.
+ * The deposit lands in the wallet itself (no rail session), so arrival is
+ * detected by a native balance increase and we don't hold the inbound tx hash —
+ * "View on Explorer" therefore opens the wallet's address page, where the
+ * incoming transfer is listed.
+ */
+export function SameChainDepositSuccess({ address, chainId }: { address: string; chainId: number }) {
+  const { setRoute, triggerResize } = useOpenfort()
+
+  // Collapse the modal from the tall deposit form down to the compact card.
+  useEffect(() => {
+    triggerResize()
+  }, [triggerResize])
+
+  const explorerUrl = getExplorerUrl(ChainTypeEnum.EVM, { chainId, address })
+
+  return (
+    <PageContent>
+      <Loader isSuccess header="Deposit received" description="Funds are in your wallet" />
+      {explorerUrl && (
+        <Button variant="primary" onClick={() => window.open(explorerUrl, '_blank', 'noopener,noreferrer')}>
+          View on Explorer
+        </Button>
+      )}
+      <Button variant="secondary" onClick={() => setRoute(routes.CONNECTED)}>
+        Back to profile
+      </Button>
+      <PoweredByFooter />
+    </PageContent>
+  )
+}

--- a/packages/openfort-react/src/components/Pages/Deposit/TestnetNotice.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/TestnetNotice.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import styled from '../../../styles/styled'
+import { getPublishableKeyEnvironment } from '../../../utils/validation'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+
+/** Relay's own testnet guide — the authoritative explanation of the limitation. */
+const RELAY_TESTNET_DOCS = 'https://docs.relay.link/references/api/api_guides/testnet#testnet-support'
+
+const FlaskIcon = () => (
+  <svg width="15" height="15" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path
+      d="M6 1.5h4M6.5 1.5v4.2L3.3 11.4A1.5 1.5 0 0 0 4.6 13.7h6.8a1.5 1.5 0 0 0 1.3-2.3L9.5 5.7V1.5"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M5.1 9h5.8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+  </svg>
+)
+
+const Card = styled.div`
+  text-align: left;
+  margin-bottom: 14px;
+  border-radius: 12px;
+  /* Amber "sandbox" tint that reads on both light and dark themes. */
+  background: rgba(245, 158, 11, 0.09);
+  border: 1px solid rgba(245, 158, 11, 0.28);
+  color: var(--ck-body-color);
+`
+
+/** The always-visible summary row; the whole row toggles the details. */
+const Header = styled.button`
+  appearance: none;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 12px;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+`
+
+const Badge = styled.span`
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 7px;
+  color: #b45309;
+  background: rgba(245, 158, 11, 0.18);
+`
+
+const Summary = styled.span`
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.3;
+`
+
+const Chevron = styled.span<{ $open: boolean }>`
+  flex-shrink: 0;
+  color: var(--ck-body-color-muted, #6b7280);
+  font-size: 11px;
+  transition: transform 150ms ease;
+  transform: rotate(${({ $open }) => ($open ? '90deg' : '0deg')});
+`
+
+const Body = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 0 12px 12px 43px;
+  font-size: 12.5px;
+  line-height: 1.45;
+`
+
+const Muted = styled.p`
+  margin: 0;
+  color: var(--ck-body-color-muted, #6b7280);
+`
+
+const Rules = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+
+  li {
+    display: flex;
+    align-items: flex-start;
+    gap: 7px;
+  }
+  li[data-ok='true']::before {
+    content: '✓';
+    color: #16a34a;
+    font-weight: 700;
+  }
+  li[data-ok='false']::before {
+    content: '✕';
+    color: #dc2626;
+    font-weight: 700;
+  }
+`
+
+const DocsLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: fit-content;
+  font-weight: 600;
+  color: var(--ck-body-color);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+
+  &:hover {
+    opacity: 0.8;
+  }
+`
+
+/**
+ * A dev-facing notice shown only for test keys (`pk_test_…`) in the Deposit flow.
+ *
+ * Collapsed by default to a single summary line; expands to explain that funding
+ * routes through Relay, whose testnet rail bridges the same asset but cannot swap
+ * to a different token (testnets lack DEX liquidity, so e.g. `ETH → USDC` fails),
+ * and that card/exchange rails are mainnet-only. Links to Relay's testnet guide.
+ * Renders nothing on live keys.
+ */
+export function TestnetNotice() {
+  const { publishableKey, triggerResize } = useOpenfort()
+  const [open, setOpen] = useState(false)
+
+  // Re-measure the modal when the details expand/collapse so it grows/shrinks to fit.
+  useEffect(() => {
+    triggerResize()
+  }, [open, triggerResize])
+
+  if (getPublishableKeyEnvironment(publishableKey) !== 'test') return null
+
+  return (
+    <Card>
+      <Header type="button" aria-expanded={open} onClick={() => setOpen((v) => !v)}>
+        <Badge>
+          <FlaskIcon />
+        </Badge>
+        <Summary>Testnet mode — funding is limited</Summary>
+        <Chevron $open={open}>▶</Chevron>
+      </Header>
+
+      {open && (
+        <Body>
+          <Muted>
+            Deposits route through Relay's testnet rail. It bridges the same asset but can't swap between tokens —
+            testnets have no DEX liquidity. Card and exchange rails are mainnet-only.
+          </Muted>
+          <Rules>
+            <li data-ok="true">Bridging the same asset (e.g. ETH → ETH) and same-chain transfers</li>
+            <li data-ok="false">Swapping to another token (e.g. → USDC) — fails with "$0 liquidity"</li>
+          </Rules>
+          <Muted>To test swaps, card or exchange deposits, use a live key on a low-cost chain like Base.</Muted>
+          <DocsLink href={RELAY_TESTNET_DOCS} target="_blank" rel="noreferrer">
+            Why? Read Relay's testnet guide ↗
+          </DocsLink>
+        </Body>
+      )}
+    </Card>
+  )
+}

--- a/packages/openfort-react/src/components/Pages/Deposit/UnsupportedNetworkNotice.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/UnsupportedNetworkNotice.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { chainConfigs } from '../../../constants/chainConfigs'
+import { useEthereumBridge } from '../../../ethereum/OpenfortEthereumBridgeContext'
+import type { FundingChain } from '../../../hooks/openfort/useFundingChains'
+import styled from '../../../styles/styled'
+import { useSwitchChainFiltered } from '../../../wagmi/useSwitchChainFiltered'
+import Chain from '../../Common/Chain'
+import { ScrollArea } from '../../Common/ScrollArea'
+import { isSolana } from './sources'
+
+/** Readable name for a CAIP-2 chain the rail can't deliver to. */
+function chainName(caip: string): string {
+  if (isSolana(caip)) return 'Solana'
+  const id = Number(caip.split(':')[1])
+  return chainConfigs.find((c) => c.id === id)?.name ?? 'this network'
+}
+
+const Card = styled.div`
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  margin-top: 4px;
+  border-radius: 12px;
+  background: var(--ck-body-background-secondary, #fafafa);
+  border: 1px solid var(--ck-body-divider, #e4e4e7);
+  color: var(--ck-body-color);
+`
+
+const Title = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+`
+
+const Body = styled.p`
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--ck-body-color-muted, #6b7280);
+`
+
+const Label = styled.div`
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ck-body-color-muted, #6b7280);
+`
+
+const SwitchButtons = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`
+
+const SwitchButton = styled.button`
+  appearance: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--ck-body-divider, #e4e4e7);
+  background: var(--ck-body-background, #fff);
+  color: var(--ck-body-color);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: var(--ck-secondary-button-hover-background, #f3f3f5);
+  }
+  &:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
+  .name {
+    flex: 1;
+    text-align: left;
+  }
+  .chevron {
+    color: var(--ck-body-color-muted, #6b7280);
+  }
+`
+
+/**
+ * Shown in the deposit flow when the active funding TARGET chain (the embedded
+ * wallet's chain) isn't one the rail can deliver to — e.g. Polygon Amoy or a
+ * Solana testnet, which Relay's testnet rail doesn't route. Explains why, and
+ * (on EVM) offers a one-tap switch to the supported chains. Solana-only contexts
+ * have no in-VM switch, so they get the explanation alone.
+ */
+export function UnsupportedNetworkNotice({
+  targetChain,
+  railChains,
+}: {
+  targetChain: string
+  railChains: FundingChain[]
+}) {
+  const bridge = useEthereumBridge()
+  return (
+    <Card>
+      <Title>Funding isn't available on {chainName(targetChain)}</Title>
+      <Body>
+        {isSolana(targetChain)
+          ? "Solana isn't supported by the funding rail in test mode. Switch to a supported EVM testnet to add funds."
+          : "The funding rail can't deliver to this network. Switch to a supported one to add funds."}
+      </Body>
+      {bridge && <SupportedChainSwitcher railChains={railChains} />}
+    </Card>
+  )
+}
+
+/**
+ * EVM-only: the rail-supported chains the wallet can switch to. Rendered only when
+ * an Ethereum bridge is present (wagmi), so the wagmi hook below never runs in a
+ * Solana-only provider tree.
+ */
+function SupportedChainSwitcher({ railChains }: { railChains: FundingChain[] }) {
+  const { chains, switchChain, isPending } = useSwitchChainFiltered()
+  const supported = chains.filter((c) => railChains.some((rc) => rc.id === `eip155:${c.id}`))
+  if (supported.length === 0) return null
+
+  return (
+    <>
+      <Label>Switch to a supported network</Label>
+      <ScrollArea height={156}>
+        <SwitchButtons>
+          {supported.map((c) => {
+            return (
+              <SwitchButton
+                key={c.id}
+                type="button"
+                disabled={isPending || !switchChain}
+                onClick={() => switchChain?.({ chainId: c.id })}
+              >
+                <Chain id={c.id} size={22} />
+                <span className="name">{c.name}</span>
+                <span className="chevron" aria-hidden>
+                  ›
+                </span>
+              </SwitchButton>
+            )
+          })}
+        </SwitchButtons>
+      </ScrollArea>
+    </>
+  )
+}

--- a/packages/openfort-react/src/components/Pages/Deposit/index.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/index.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import { ChainTypeEnum } from '@openfort/openfort-js'
-import type { ReactNode, SyntheticEvent } from 'react'
+import { type ReactNode, type SyntheticEvent, useEffect } from 'react'
 import { BuyIcon, DollarIcon, ExternalLinkIcon, ReceiveIcon, WalletIcon } from '../../../assets/icons'
 import logos from '../../../assets/logos'
 import { useFunding } from '../../../hooks/openfort/useFunding'
 import { useFundingChains } from '../../../hooks/openfort/useFundingChains'
 import useIsMobile from '../../../hooks/useIsMobile'
 import { useOpenfortCore } from '../../../openfort/useOpenfort'
+import { getPublishableKeyEnvironment } from '../../../utils/validation'
 import { ModalHeading } from '../../Common/Modal/styles'
 import PoweredByFooter from '../../Common/PoweredByFooter'
 import { FundingMethod, routes } from '../../Openfort/types'
@@ -27,6 +28,9 @@ import {
   OptionSubtitle,
   OptionTitle,
 } from './styles'
+import { TestnetNotice } from './TestnetNotice'
+import { UnsupportedNetworkNotice } from './UnsupportedNetworkNotice'
+import { useFundingTarget } from './useFundingTarget'
 
 /** The action icon shown in each row's left badge (icons default to 20×20). */
 const METHOD_ICON: Record<FundingMethod, ReactNode> = {
@@ -61,15 +65,28 @@ const hideBrokenLogo = (e: SyntheticEvent<HTMLImageElement>) => {
  * Crypto/CEX route into the funding-session Pages; fiat rows reuse the Buy flow.
  */
 const Deposit = () => {
-  const { setRoute, setBuyForm, uiConfig } = useOpenfort()
+  const { setRoute, setBuyForm, uiConfig, publishableKey, triggerResize } = useOpenfort()
   const { chainType } = useOpenfortCore()
   const isMobile = useIsMobile()
   const { isAvailable } = useFunding()
-  const { chains } = useFundingChains()
+  const { chains, railChains, loading: chainsLoading } = useFundingChains()
+  const target = useFundingTarget()
+
+  // The rail can only deliver to chains it lists. If the embedded wallet's target
+  // chain (e.g. Polygon Amoy or a Solana testnet) isn't one of them, there's no
+  // deposit route at all — show the explanation instead of any method options.
+  const targetUnsupported = !chainsLoading && railChains.length > 0 && !railChains.some((c) => c.id === target.chain)
+
+  // Content swaps between the option list and the notice once chains resolve; the
+  // modal only re-measures on an explicit resize, so nudge it when that flips.
+  useEffect(() => {
+    triggerResize()
+  }, [targetUnsupported, triggerResize])
 
   const options = getPaymentOptions({
     isMobile,
     fundingAvailable: isAvailable,
+    testnet: getPublishableKeyEnvironment(publishableKey) === 'test',
     methods: uiConfig.funding?.methods,
   })
 
@@ -126,22 +143,27 @@ const Deposit = () => {
   return (
     <PageContent onBack={routes.CONNECTED}>
       <ModalHeading>Add funds</ModalHeading>
-      <DepositContent>
-        <OptionList>
-          {options.map((option) => (
-            <OptionButton key={option.id} type="button" disabled={option.disabled} onClick={() => go(option.target)}>
-              <OptionLeft>
-                <OptionIconBadge>{METHOD_ICON[option.id]}</OptionIconBadge>
-                <OptionInfo>
-                  <OptionTitle>{option.title}</OptionTitle>
-                  <OptionSubtitle>{option.disabledReason ?? option.subtitle}</OptionSubtitle>
-                </OptionInfo>
-              </OptionLeft>
-              <LogoCluster>{clusterFor(option.id)}</LogoCluster>
-            </OptionButton>
-          ))}
-        </OptionList>
-      </DepositContent>
+      <TestnetNotice />
+      {targetUnsupported ? (
+        <UnsupportedNetworkNotice targetChain={target.chain} railChains={railChains} />
+      ) : (
+        <DepositContent>
+          <OptionList>
+            {options.map((option) => (
+              <OptionButton key={option.id} type="button" disabled={option.disabled} onClick={() => go(option.target)}>
+                <OptionLeft>
+                  <OptionIconBadge>{METHOD_ICON[option.id]}</OptionIconBadge>
+                  <OptionInfo>
+                    <OptionTitle>{option.title}</OptionTitle>
+                    <OptionSubtitle>{option.disabledReason ?? option.subtitle}</OptionSubtitle>
+                  </OptionInfo>
+                </OptionLeft>
+                <LogoCluster>{clusterFor(option.id)}</LogoCluster>
+              </OptionButton>
+            ))}
+          </OptionList>
+        </DepositContent>
+      )}
       <PoweredByFooter />
     </PageContent>
   )

--- a/packages/openfort-react/src/components/Pages/Deposit/paymentOptions.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/paymentOptions.ts
@@ -27,6 +27,12 @@ type PaymentOptionsContext = {
   /** When the funding backend is unavailable, crypto/CEX rows are disabled. */
   fundingAvailable: boolean
   /**
+   * Test-key (`pk_test_…`) project. The fiat (card/Apple Pay) and exchange rails
+   * settle real money on mainnet only — Stripe/Coinbase can't deliver to a testnet
+   * wallet — so they're disabled here. The crypto rails (Relay testnet) stay on.
+   */
+  testnet?: boolean
+  /**
    * Integrator-selected methods, in display order. When set, only these show
    * (still subject to device/availability gating). Omit to show all.
    */
@@ -95,8 +101,13 @@ export function getPaymentOptions(ctx: PaymentOptionsContext): ResolvedDepositOp
       : visible
 
   return ordered.map((method) => {
-    const fundingRail =
-      method.target.kind === 'crypto' || method.target.kind === 'wallet' || method.target.kind === 'cex'
+    const kind = method.target.kind
+    // Fiat (card/Apple Pay) and exchange rails move real money and only settle on
+    // mainnet, so a test-key project can't use them — disable with a clear reason.
+    if (ctx.testnet && (kind === 'buy' || kind === 'cex')) {
+      return { ...method, disabled: true, disabledReason: 'Not available on testnet' }
+    }
+    const fundingRail = kind === 'crypto' || kind === 'wallet' || kind === 'cex'
     if (fundingRail && !ctx.fundingAvailable) {
       return { ...method, disabled: true, disabledReason: 'Coming soon' }
     }

--- a/packages/openfort-react/src/components/Pages/Deposit/useDepositRoute.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/useDepositRoute.ts
@@ -35,7 +35,7 @@ export function useDepositRoute(kind: DepositRouteKind) {
   const ethWallet = useEthereumEmbeddedWallet()
   const solWallet = useSolanaEmbeddedWallet()
   const { session, status, error, loading, isAvailable, fund, payLink, reset } = useFunding()
-  const { chains: allChains, loading: chainsLoading } = useFundingChains()
+  const { chains: allChains, railChains, loading: chainsLoading } = useFundingChains()
   const target = useFundingTarget()
   // The deposit recipient must live on the TARGET chain, so resolve the wallet by
   // the target's family — not the active chainType, which can disagree with the
@@ -61,6 +61,11 @@ export function useDepositRoute(kind: DepositRouteKind) {
   const activeCurrency = currencies.find((c) => c.symbol === currencySymbol) ?? currencies[0]
   const chain = activeChain?.id ?? target.chain
   const sameChain = chain === target.chain
+  // The rail only delivers to chains in its list; if the active funding TARGET (the
+  // embedded wallet's chain — e.g. Polygon Amoy or a Solana testnet) isn't one of
+  // them, there's no route. Don't call Relay (it would 400 with a cryptic "invalid
+  // currency"); the page prompts a switch to a supported chain instead.
+  const targetUnsupported = !chainsLoading && railChains.length > 0 && !railChains.some((c) => c.id === target.chain)
   const receiverAddress: string | null = sameChain
     ? (address ?? null)
     : (session?.paymentMethod?.receiverAddress ?? null)
@@ -68,6 +73,11 @@ export function useDepositRoute(kind: DepositRouteKind) {
 
   useEffect(() => {
     if (!address || !isAvailable || !activeChain || !activeCurrency) return
+    if (targetUnsupported) {
+      lastKey.current = ''
+      reset()
+      return
+    }
     if (sameChain) {
       lastKey.current = ''
       reset()
@@ -86,7 +96,19 @@ export function useDepositRoute(kind: DepositRouteKind) {
       { chain: target.chain, currency: target.currency, address },
       paymentMethodFor(activeChain.id, activeCurrency)
     ).catch(() => {})
-  }, [address, activeChain, activeCurrency, isAvailable, sameChain, fund, reset, target.chain, target.currency, kind])
+  }, [
+    address,
+    activeChain,
+    activeCurrency,
+    isAvailable,
+    sameChain,
+    targetUnsupported,
+    fund,
+    reset,
+    target.chain,
+    target.currency,
+    kind,
+  ])
 
   // Surface an empty source list (e.g. no Coinbase-deliverable chains) for diagnosis.
   useEffect(() => {
@@ -109,6 +131,8 @@ export function useDepositRoute(kind: DepositRouteKind) {
     pm,
     receiverAddress,
     sameChain,
+    targetUnsupported,
+    railChains,
     status,
     loading,
     error,

--- a/packages/openfort-react/src/components/Pages/Deposit/useSameChainArrival.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/useSameChainArrival.ts
@@ -1,0 +1,93 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { createPublicClient, http } from 'viem'
+import { invalidateBalance } from '../../../hooks/useBalance'
+import { getDefaultEthereumRpcUrl } from '../../../utils/rpc'
+import { useOpenfort } from '../../Openfort/useOpenfort'
+
+/**
+ * Backoff schedule (ms) for the waiting poll: brisk at first, easing off so a
+ * long wait doesn't hammer the RPC. The last entry is the steady-state cap.
+ */
+const POLL_BACKOFF_MS = [2_000, 2_000, 3_000, 5_000, 8_000, 12_000, 20_000] as const
+
+/**
+ * Watches a wallet's native balance and reports when it increases past the first
+ * observed value — i.e. a same-chain deposit landed. Same-chain "transfer from
+ * address" has no rail session to poll (the deposit address is the wallet
+ * itself), so arrival is read straight from the chain RPC.
+ *
+ * Self-contained single timeout chain (no shared query cache), so it can't fan
+ * out into a request storm: one read in flight at a time, with an interval that
+ * grows on each tick and resets to brisk when the user returns to the tab (the
+ * moment a deposit was likely just made). On arrival, cached balances are
+ * invalidated so the asset list refreshes, and polling stops.
+ */
+export function useSameChainArrival({
+  address,
+  chainId,
+  enabled,
+}: {
+  address: string
+  chainId: number
+  enabled: boolean
+}): { arrived: boolean } {
+  const { walletConfig } = useOpenfort()
+  const rpcUrl = walletConfig?.ethereum?.rpcUrls?.[chainId] ?? getDefaultEthereumRpcUrl(chainId)
+
+  const [arrived, setArrived] = useState(false)
+  const baselineRef = useRef<bigint | null>(null)
+
+  useEffect(() => {
+    if (!enabled || !address) return
+
+    const client = createPublicClient({ transport: http(rpcUrl) })
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let step = 0
+    baselineRef.current = null
+
+    const read = async () => {
+      try {
+        const balance = await client.getBalance({ address: address as `0x${string}` })
+        if (cancelled) return
+        if (baselineRef.current === null) {
+          baselineRef.current = balance
+        } else if (balance > baselineRef.current) {
+          setArrived(true)
+          invalidateBalance()
+          return // deposit landed — stop polling
+        }
+      } catch {
+        // transient RPC error — keep polling on the same schedule
+      }
+      if (cancelled) return
+      const delay = POLL_BACKOFF_MS[Math.min(step, POLL_BACKOFF_MS.length - 1)]
+      step += 1
+      timer = setTimeout(read, delay)
+    }
+
+    // Re-check immediately when the user returns to the tab (deposit likely just
+    // made), and reset the schedule back to brisk.
+    const onReturn = () => {
+      if (cancelled || document.visibilityState !== 'visible') return
+      if (timer) clearTimeout(timer)
+      step = 0
+      read()
+    }
+
+    read()
+    document.addEventListener('visibilitychange', onReturn)
+    window.addEventListener('focus', onReturn)
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+      document.removeEventListener('visibilitychange', onReturn)
+      window.removeEventListener('focus', onReturn)
+    }
+  }, [enabled, address, chainId, rpcUrl])
+
+  return { arrived }
+}

--- a/packages/openfort-react/src/components/Pages/DepositCrypto/index.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositCrypto/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import { chainLogoUrl, currencyLogoUrl } from '../../../constants/logos'
 import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
 import { routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
@@ -8,7 +9,14 @@ import { PageContent } from '../../PageContent'
 import { DepositAddressBlock } from '../Deposit/DepositAddressBlock'
 import { DepositProgress, isDepositFlowActive } from '../Deposit/DepositProgress'
 import { RouteSelectors } from '../Deposit/RouteSelectors'
+import { SameChainDepositStatus } from '../Deposit/SameChainDepositStatus'
+import { SameChainDepositSuccess } from '../Deposit/SameChainDepositSuccess'
+import { isSolana } from '../Deposit/sources'
+import { TestnetNotice } from '../Deposit/TestnetNotice'
+import { UnsupportedNetworkNotice } from '../Deposit/UnsupportedNetworkNotice'
 import { useDepositRoute } from '../Deposit/useDepositRoute'
+import { useSameChainArrival } from '../Deposit/useSameChainArrival'
+import { caipToChainId } from '../DepositWallet/walletDeeplinks'
 
 /**
  * Transfer from address — choose a source chain + token and send to the deposit
@@ -24,35 +32,59 @@ const DepositCrypto = () => {
     triggerResize()
   }, [route.receiverAddress, route.loading, route.status, triggerResize])
 
+  // Same-chain "transfer from address" lands in the wallet itself, so there's no
+  // rail session — watch the native balance directly and swap to the success
+  // screen once the deposit arrives.
+  const sameChainEnabled = route.sameChain && !!route.receiverAddress && !isSolana(route.target.chain)
+  const sameChainAddress = route.receiverAddress ?? ''
+  const sameChainId = Number(route.target.chain.split(':')[1])
+  const { arrived } = useSameChainArrival({
+    address: sameChainAddress,
+    chainId: sameChainId,
+    enabled: sameChainEnabled,
+  })
+
   if (isDepositFlowActive(route.status)) return <DepositProgress status={route.status} />
+  if (sameChainEnabled && arrived) return <SameChainDepositSuccess address={sameChainAddress} chainId={sameChainId} />
 
   return (
     <PageContent onBack={routes.DEPOSIT}>
       <ModalHeading>Transfer from address</ModalHeading>
 
-      <RouteSelectors
-        chains={route.chains}
-        chain={route.chain}
-        currency={route.currency}
-        chainLabel="Supported chain"
-        onChainChange={route.setChain}
-        onCurrencyChange={route.setCurrency}
-      />
+      <TestnetNotice />
 
-      {!route.isAvailable && <ModalBody>Funding isn't available right now.</ModalBody>}
-      <DepositAddressBlock
-        assetLogo={route.activeCurrency?.logo ?? null}
-        chainLogo={route.activeChain?.logo ?? null}
-        receiverAddress={route.receiverAddress}
-        pm={route.pm}
-        sourceCurrency={
-          route.activeCurrency ? { symbol: route.activeCurrency.symbol, decimals: route.activeCurrency.decimals } : null
-        }
-        sameChain={route.sameChain}
-        loading={route.loading}
-        status={route.status}
-      />
-      {route.error && <ModalBody style={{ color: '#dc2626', marginTop: 12 }}>{route.error.message}</ModalBody>}
+      {route.targetUnsupported ? (
+        <UnsupportedNetworkNotice targetChain={route.target.chain} railChains={route.railChains} />
+      ) : (
+        <>
+          <RouteSelectors
+            chains={route.chains}
+            chain={route.chain}
+            currency={route.currency}
+            chainLabel="Supported chain"
+            onChainChange={route.setChain}
+            onCurrencyChange={route.setCurrency}
+          />
+
+          {!route.isAvailable && <ModalBody>Funding isn't available right now.</ModalBody>}
+          <DepositAddressBlock
+            assetLogo={currencyLogoUrl(route.activeCurrency?.symbol, route.activeCurrency?.logo)}
+            chainLogo={chainLogoUrl(caipToChainId(route.activeChain?.id), route.activeChain?.logo)}
+            receiverAddress={route.receiverAddress}
+            pm={route.pm}
+            sourceCurrency={
+              route.activeCurrency
+                ? { symbol: route.activeCurrency.symbol, decimals: route.activeCurrency.decimals }
+                : null
+            }
+            sameChain={route.sameChain}
+            loading={route.loading}
+            status={route.status}
+          />
+          {sameChainEnabled && <SameChainDepositStatus />}
+          {route.error && <ModalBody style={{ color: '#dc2626', marginTop: 12 }}>{route.error.message}</ModalBody>}
+        </>
+      )}
     </PageContent>
   )
 }

--- a/packages/openfort-react/src/components/Pages/DepositWallet/index.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositWallet/index.tsx
@@ -19,6 +19,8 @@ import { walletListBtn } from '../Deposit/formStyles'
 import { RouteSelectors } from '../Deposit/RouteSelectors'
 import { isSolana } from '../Deposit/sources'
 import { ButtonLogo, Skeleton, StepDivider } from '../Deposit/styles'
+import { TestnetNotice } from '../Deposit/TestnetNotice'
+import { UnsupportedNetworkNotice } from '../Deposit/UnsupportedNetworkNotice'
 import { useDepositRoute } from '../Deposit/useDepositRoute'
 import { sanitizeAmountInput } from '../Send/utils'
 import { DepositWalletDesktop } from './DepositWalletDesktop'
@@ -85,7 +87,9 @@ const DepositWallet = () => {
   const { triggerResize, uiConfig } = useOpenfort()
   const isMobile = useIsMobile()
   const route = useDepositRoute('crypto')
-  const [amount, setAmount] = useState('')
+  // Prefill a sensible default so the wallet deeplinks are immediately actionable
+  // (the funding deposit-address mint uses a fixed nominal amount regardless).
+  const [amount, setAmount] = useState('1')
   const [pressedPreset, setPressedPreset] = useState<number | null>(null)
 
   const depositPageUrl = uiConfig.funding?.depositPageUrl ?? OPENFORT_DEPOSIT_PAGE_URL
@@ -146,108 +150,116 @@ const DepositWallet = () => {
     <PageContent onBack={routes.DEPOSIT}>
       <ModalHeading>Transfer from wallet</ModalHeading>
 
-      <Layout>
-        <TopFixed>
-          <RouteSelectors
-            chains={route.chains}
-            chain={route.chain}
-            currency={route.currency}
-            chainLabel="Supported chain"
-            onChainChange={route.setChain}
-            onCurrencyChange={route.setCurrency}
-          />
+      <TestnetNotice />
 
-          {!route.isAvailable && <ModalBody>Funding isn't available right now.</ModalBody>}
+      {route.targetUnsupported && (
+        <UnsupportedNetworkNotice targetChain={route.target.chain} railChains={route.railChains} />
+      )}
 
-          <Section>
-            <SectionLabel>Amount</SectionLabel>
-            <AmountCard>
-              <CurrencySymbol>{route.activeCurrency?.symbol ?? ''}</CurrencySymbol>
-              <AmountInput
-                value={amount}
-                onChange={handleAmountChange}
-                placeholder="0.00"
-                inputMode="decimal"
-                autoComplete="off"
-              />
-            </AmountCard>
-            <PresetList>
-              {PRESETS.map((preset) => (
-                <PresetButton
-                  key={preset}
-                  type="button"
-                  $active={pressedPreset === preset}
-                  onClick={() => handlePreset(preset)}
-                >
-                  {preset}
-                </PresetButton>
-              ))}
-            </PresetList>
-          </Section>
-
-          <StepDivider>Then select the wallet you want to use</StepDivider>
-        </TopFixed>
-
-        <ProvidersRegion>
-          {isMobile || isSolanaSrc ? (
-            <>
-              {!depositPageUrl && (
-                <ModalBody style={{ marginTop: 12 }}>Use a deposit address below to fund from your wallet.</ModalBody>
-              )}
-
-              {route.loading && !route.pm && (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                  <Skeleton $h="44px" $r="10px" />
-                  <Skeleton $h="44px" $r="10px" />
-                  <Skeleton $h="44px" $r="10px" />
-                </div>
-              )}
-
-              {deeplinks.length > 0 && (
-                <ScrollArea fill>
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                    {deeplinks.map((d) => (
-                      <a
-                        key={d.app}
-                        href={amountValid ? d.url : undefined}
-                        aria-disabled={!amountValid}
-                        target="_blank"
-                        rel="noreferrer"
-                        style={{
-                          ...walletListBtn,
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          gap: 8,
-                          opacity: amountValid ? 1 : 0.55,
-                          pointerEvents: amountValid ? 'auto' : 'none',
-                        }}
-                      >
-                        {WALLET_LOGO[d.app] && <ButtonLogo>{WALLET_LOGO[d.app]}</ButtonLogo>}
-                        {d.label} ↗
-                      </a>
-                    ))}
-                  </div>
-                </ScrollArea>
-              )}
-            </>
-          ) : (
-            <DepositWalletDesktop
-              receiverAddress={route.receiverAddress}
-              activeChain={route.activeChain}
-              activeCurrency={route.activeCurrency}
-              loading={route.loading}
-              amount={amount}
+      {!route.targetUnsupported && (
+        <Layout>
+          <TopFixed>
+            <RouteSelectors
+              chains={route.chains}
+              chain={route.chain}
+              currency={route.currency}
+              chainLabel="Supported chain"
+              onChainChange={route.setChain}
+              onCurrencyChange={route.setCurrency}
             />
-          )}
-        </ProvidersRegion>
 
-        <FixedFooter>
-          <AddressPageLink label="Or send to a deposit address" />
+            {!route.isAvailable && <ModalBody>Funding isn't available right now.</ModalBody>}
 
-          {route.error && <ModalBody style={{ color: '#dc2626', marginTop: 12 }}>{route.error.message}</ModalBody>}
-        </FixedFooter>
-      </Layout>
+            <Section>
+              <SectionLabel>Amount</SectionLabel>
+              <AmountCard>
+                <CurrencySymbol>{route.activeCurrency?.symbol ?? ''}</CurrencySymbol>
+                <AmountInput
+                  value={amount}
+                  onChange={handleAmountChange}
+                  placeholder="0.00"
+                  inputMode="decimal"
+                  autoComplete="off"
+                />
+              </AmountCard>
+              <PresetList>
+                {PRESETS.map((preset) => (
+                  <PresetButton
+                    key={preset}
+                    type="button"
+                    $active={pressedPreset === preset}
+                    onClick={() => handlePreset(preset)}
+                  >
+                    {preset}
+                  </PresetButton>
+                ))}
+              </PresetList>
+            </Section>
+
+            <StepDivider>Then select the wallet you want to use</StepDivider>
+          </TopFixed>
+
+          <ProvidersRegion>
+            {isMobile || isSolanaSrc ? (
+              <>
+                {!depositPageUrl && (
+                  <ModalBody style={{ marginTop: 12 }}>Use a deposit address below to fund from your wallet.</ModalBody>
+                )}
+
+                {route.loading && !route.pm && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    <Skeleton $h="44px" $r="10px" />
+                    <Skeleton $h="44px" $r="10px" />
+                    <Skeleton $h="44px" $r="10px" />
+                  </div>
+                )}
+
+                {deeplinks.length > 0 && (
+                  <ScrollArea fill>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                      {deeplinks.map((d) => (
+                        <a
+                          key={d.app}
+                          href={amountValid ? d.url : undefined}
+                          aria-disabled={!amountValid}
+                          target="_blank"
+                          rel="noreferrer"
+                          style={{
+                            ...walletListBtn,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            gap: 8,
+                            opacity: amountValid ? 1 : 0.55,
+                            pointerEvents: amountValid ? 'auto' : 'none',
+                          }}
+                        >
+                          {WALLET_LOGO[d.app] && <ButtonLogo>{WALLET_LOGO[d.app]}</ButtonLogo>}
+                          {d.label} ↗
+                        </a>
+                      ))}
+                    </div>
+                  </ScrollArea>
+                )}
+              </>
+            ) : (
+              <DepositWalletDesktop
+                receiverAddress={route.receiverAddress}
+                activeChain={route.activeChain}
+                activeCurrency={route.activeCurrency}
+                loading={route.loading}
+                amount={amount}
+              />
+            )}
+          </ProvidersRegion>
+
+          <FixedFooter>
+            <AddressPageLink label="Or send to a deposit address" />
+
+            {route.error && <ModalBody style={{ color: '#dc2626', marginTop: 12 }}>{route.error.message}</ModalBody>}
+          </FixedFooter>
+        </Layout>
+      )}
     </PageContent>
   )
 }

--- a/packages/openfort-react/src/components/Pages/SendConfirmation/index.tsx
+++ b/packages/openfort-react/src/components/Pages/SendConfirmation/index.tsx
@@ -390,9 +390,11 @@ const SendConfirmation = () => {
       <PageContent>
         <Loader isSuccess header="Transfer Sent" description={`${successAmount} ${successSymbol} sent successfully`} />
         <ButtonRow>
-          <Button variant="primary" onClick={handleOpenBlockExplorer}>
-            View on Explorer
-          </Button>
+          {blockExplorerUrl && (
+            <Button variant="primary" onClick={handleOpenBlockExplorer}>
+              View on Explorer
+            </Button>
+          )}
           <Button variant="secondary" onClick={handleFinish}>
             Back to profile
           </Button>

--- a/packages/openfort-react/src/constants/chainConfigs.tsx
+++ b/packages/openfort-react/src/constants/chainConfigs.tsx
@@ -45,28 +45,28 @@ export const chainConfigs: Chain[] = [
   {
     id: 37111,
     name: 'Lens Chain Testnet',
-    logo: <Logos.LensChain testnet />,
+    logo: <Logos.LensChain />,
   },
   {
     id: 3,
     name: 'Rinkeby',
-    logo: <Logos.Ethereum testnet />,
+    logo: <Logos.Ethereum />,
     rpcUrls: {},
   },
   {
     id: 4,
     name: 'Ropsten',
-    logo: <Logos.Ethereum testnet />,
+    logo: <Logos.Ethereum />,
   },
   {
     id: 5,
     name: 'Görli',
-    logo: <Logos.Ethereum testnet />,
+    logo: <Logos.Ethereum />,
   },
   {
     id: 42,
     name: 'Kovan',
-    logo: <Logos.Ethereum testnet />,
+    logo: <Logos.Ethereum />,
   },
   {
     id: 10,
@@ -76,17 +76,17 @@ export const chainConfigs: Chain[] = [
   {
     id: 69, // nice
     name: 'Optimism Kovan',
-    logo: <Logos.Optimism testnet />,
+    logo: <Logos.Optimism />,
   },
   {
     id: 420, // nice
     name: 'Optimism Goerli',
-    logo: <Logos.Optimism testnet />,
+    logo: <Logos.Optimism />,
   },
   {
     id: 11155420,
     name: 'Optimism Sepolia',
-    logo: <Logos.Optimism testnet />,
+    logo: <Logos.Optimism />,
   },
   {
     id: 137,
@@ -96,27 +96,27 @@ export const chainConfigs: Chain[] = [
   {
     id: 80001,
     name: 'Polygon Mumbai',
-    logo: <Logos.Polygon testnet />,
+    logo: <Logos.Polygon />,
   },
   {
     id: 80002,
     name: 'Polygon Amoy',
-    logo: <Logos.Polygon testnet />,
+    logo: <Logos.Polygon />,
   },
   {
     id: 13337,
     name: 'Beam Testnet',
-    logo: <Logos.Avalanche testnet />,
+    logo: <Logos.Avalanche />,
   },
   {
     id: 31337,
     name: 'Hardhat',
-    logo: <Logos.Ethereum testnet />,
+    logo: <Logos.Ethereum />,
   },
   {
     id: 1337,
     name: 'Localhost',
-    logo: <Logos.Ethereum testnet />,
+    logo: <Logos.Ethereum />,
   },
   {
     id: 42161,
@@ -136,12 +136,12 @@ export const chainConfigs: Chain[] = [
   {
     id: 421611,
     name: 'Arbitrum Rinkeby',
-    logo: <Logos.Arbitrum testnet />,
+    logo: <Logos.Arbitrum />,
   },
   {
     id: 421613,
     name: 'Arbitrum Goerli',
-    logo: <Logos.Arbitrum testnet />,
+    logo: <Logos.Arbitrum />,
     rpcUrls: {
       alchemy: {
         http: ['https://arb-goerli.g.alchemy.com/v2'],
@@ -161,7 +161,7 @@ export const chainConfigs: Chain[] = [
   {
     id: 41,
     name: 'Telos Testnet',
-    logo: <Logos.Telos testnet />,
+    logo: <Logos.Telos />,
   },
   {
     id: 1313161554,
@@ -171,7 +171,7 @@ export const chainConfigs: Chain[] = [
   {
     id: 1313161555,
     name: 'Aurora Testnet',
-    logo: <Logos.Aurora testnet />,
+    logo: <Logos.Aurora />,
   },
   {
     id: 43_114,
@@ -181,12 +181,12 @@ export const chainConfigs: Chain[] = [
   {
     id: 43_113,
     name: 'Avalanche Fuji',
-    logo: <Logos.Avalanche testnet />,
+    logo: <Logos.Avalanche />,
   },
   {
     id: 31337,
     name: 'Foundry',
-    logo: <Logos.Foundry testnet />,
+    logo: <Logos.Foundry />,
   },
   {
     id: 100,
@@ -201,7 +201,7 @@ export const chainConfigs: Chain[] = [
   {
     id: 9000,
     name: 'Evmos Testnet',
-    logo: <Logos.Evmos testnet />,
+    logo: <Logos.Evmos />,
   },
   {
     id: 56,
@@ -211,7 +211,7 @@ export const chainConfigs: Chain[] = [
   {
     id: 97,
     name: 'Binance Smart Chain Testnet',
-    logo: <Logos.BinanceSmartChain testnet />,
+    logo: <Logos.BinanceSmartChain />,
   },
   {
     id: 11155111,
@@ -226,7 +226,7 @@ export const chainConfigs: Chain[] = [
   {
     id: 842,
     name: 'Taraxa Testnet',
-    logo: <Logos.Taraxa testnet />,
+    logo: <Logos.Taraxa />,
   },
   {
     id: 324,
@@ -236,7 +236,7 @@ export const chainConfigs: Chain[] = [
   {
     id: 280,
     name: 'zkSync Testnet',
-    logo: <Logos.zkSync testnet />,
+    logo: <Logos.zkSync />,
   },
   {
     id: 42_220,
@@ -246,7 +246,7 @@ export const chainConfigs: Chain[] = [
   {
     id: 44_787,
     name: 'Celo Alfajores',
-    logo: <Logos.Celo testnet />,
+    logo: <Logos.Celo />,
   },
   {
     id: 7_700,
@@ -271,12 +271,12 @@ export const chainConfigs: Chain[] = [
   {
     id: 314_1,
     name: 'Filecoin Hyperspace',
-    logo: <Logos.Filecoin testnet />,
+    logo: <Logos.Filecoin />,
   },
   {
     id: 314_159,
     name: 'Filecoin Calibration',
-    logo: <Logos.Filecoin testnet />,
+    logo: <Logos.Filecoin />,
   },
   {
     id: 1_088,
@@ -286,7 +286,7 @@ export const chainConfigs: Chain[] = [
   {
     id: 599,
     name: 'Metis Goerli',
-    logo: <Logos.Metis testnet />,
+    logo: <Logos.Metis />,
   },
   {
     id: 4_689,
@@ -296,7 +296,7 @@ export const chainConfigs: Chain[] = [
   {
     id: 4_690,
     name: 'IoTeX Testnet',
-    logo: <Logos.IoTeX testnet />,
+    logo: <Logos.IoTeX />,
   },
   {
     id: 8_453,
@@ -306,12 +306,12 @@ export const chainConfigs: Chain[] = [
   {
     id: 84_531,
     name: 'Base Goerli',
-    logo: <Logos.Base testnet />,
+    logo: <Logos.Base />,
   },
   {
     id: 84_532,
     name: 'Base Sepolia',
-    logo: <Logos.Base testnet />,
+    logo: <Logos.Base />,
   },
   {
     id: 7777777,
@@ -321,11 +321,11 @@ export const chainConfigs: Chain[] = [
   {
     id: 999999999,
     name: 'Zora Sepolia',
-    logo: <Logos.Zora testnet />,
+    logo: <Logos.Zora />,
   },
   {
     id: 999,
     name: 'Zora Goerli Testnet',
-    logo: <Logos.Zora testnet />,
+    logo: <Logos.Zora />,
   },
 ]

--- a/packages/openfort-react/src/constants/logos.ts
+++ b/packages/openfort-react/src/constants/logos.ts
@@ -56,3 +56,30 @@ export function symbolToColor(symbol: string): string {
   const h = ((hash % 360) + 360) % 360
   return `hsl(${h}, 55%, 50%)`
 }
+
+// EVM chain id -> network logo URL. Testnet ids reuse their mainnet brand. Used
+// instead of the funding rail's icon CDN, which serves a generic prism for
+// testnets and a blank square for some mainnets.
+const CHAIN_LOGO: Record<number, string> = {
+  1: `${TW}/ethereum/info/logo.png`,
+  11155111: `${TW}/ethereum/info/logo.png`, // Sepolia
+  8453: `${TW}/base/info/logo.png`,
+  84532: `${TW}/base/info/logo.png`, // Base Sepolia
+  10: `${TW}/optimism/info/logo.png`,
+  11155420: `${TW}/optimism/info/logo.png`, // OP Sepolia
+  42161: `${TW}/arbitrum/info/logo.png`,
+  421614: `${TW}/arbitrum/info/logo.png`, // Arbitrum Sepolia
+  137: `${TW}/polygon/info/logo.png`,
+  80002: `${TW}/polygon/info/logo.png`, // Polygon Amoy
+  56: `${TW}/smartchain/info/logo.png`,
+}
+
+/** Network logo for a chain: the curated brand first (clean + testnet-aware), then the backend value. */
+export function chainLogoUrl(chainId?: number, apiLogo?: string | null): string | null {
+  return (chainId !== undefined && CHAIN_LOGO[chainId]) || apiLogo || null
+}
+
+/** Token logo for a symbol: the backend value first, then the curated map (covers native ETH/SOL/… which the rail returns null for). */
+export function currencyLogoUrl(symbol?: string, apiLogo?: string | null): string | null {
+  return apiLogo || (symbol && TOKEN_LOGO[symbol.toUpperCase()]) || null
+}

--- a/packages/openfort-react/src/ethereum/hooks/useEthereumWalletAssets.ts
+++ b/packages/openfort-react/src/ethereum/hooks/useEthereumWalletAssets.ts
@@ -344,6 +344,24 @@ export const useEthereumWalletAssets = ({
             }
           }
         }
+        // The ERC-7811 proxy indexes mainnet; testnet natives (e.g. Base Sepolia ETH)
+        // come back missing or stale. For configured testnet chains, read the native
+        // balance straight from RPC — the same source Rabby uses — and upsert it.
+        const testnetChains = chains.filter((c) => c.testnet === true)
+        const rpcNatives = await Promise.all(
+          testnetChains.map(async (c) => {
+            const rpcUrl = walletConfig?.ethereum?.rpcUrls?.[c.id] ?? getDefaultEthereumRpcUrl(c.id)
+            const read = await readEvmAssetsViaRpc({ address: address as `0x${string}`, chain: c, rpcUrl, tokens: [] })
+            const native = read.find((a) => a.type === 'native')
+            return native ? ({ ...native, chainId: c.id } as MultiChainAsset) : null
+          })
+        )
+        for (const native of rpcNatives) {
+          if (!native) continue
+          const idx = allAssets.findIndex((a) => a.type === 'native' && a.chainId === native.chainId)
+          if (idx >= 0) allAssets[idx] = native
+          else allAssets.push(native)
+        }
         allAssets.sort((a, b) => getUsdValue(b) - getUsdValue(a))
         return allAssets as readonly MultiChainAsset[]
       }
@@ -457,6 +475,21 @@ export const useEthereumWalletAssets = ({
             mergedAssets.push(asset)
           }
         })
+
+        // The ERC-7811 proxy indexes mainnet; a testnet native (e.g. Base Sepolia
+        // ETH) comes back missing or stale, so the single-chain path would report
+        // "no assets" while the multi-chain inventory shows the balance. Read the
+        // native straight from RPC and upsert it to keep the two consistent.
+        if (chain.testnet === true) {
+          const rpcUrl = walletConfig?.ethereum?.rpcUrls?.[chainId] ?? getDefaultEthereumRpcUrl(chainId)
+          const read = await readEvmAssetsViaRpc({ address: address as `0x${string}`, chain, rpcUrl, tokens: [] })
+          const native = read.find((a) => a.type === 'native')
+          if (native) {
+            const idx = mergedAssets.findIndex((a) => a.type === 'native')
+            if (idx >= 0) mergedAssets[idx] = native
+            else mergedAssets.unshift(native)
+          }
+        }
 
         if (mergedAssets.length === 0 && customAssetsToFetch.length > 0) {
           // Proxy succeeded but returned nothing while we expect tokens — read direct.

--- a/packages/openfort-react/src/hooks/openfort/useFundingChains.ts
+++ b/packages/openfort-react/src/hooks/openfort/useFundingChains.ts
@@ -3,6 +3,7 @@
 import { SDKConfiguration } from '@openfort/openfort-js'
 import { useEffect, useState } from 'react'
 import { useOpenfort } from '../../components/Openfort/useOpenfort'
+import { getPublishableKeyEnvironment } from '../../utils/validation'
 
 /** A source currency available on a chain (sourced live from Relay via the backend). */
 export type FundingCurrency = {
@@ -28,6 +29,12 @@ export type FundingChain = {
 
 type UseFundingChains = {
   chains: FundingChain[]
+  /**
+   * The rail's full deliverable chain list (uncurated). Used to check whether a
+   * funding TARGET chain is supported, independent of the source allowlist that
+   * narrows {@link chains}.
+   */
+  railChains: FundingChain[]
   loading: boolean
   error: Error | null
 }
@@ -63,17 +70,25 @@ const DEFAULT_SOURCE_CURRENCIES = ['native', 'USDC', 'USDT']
  * Returns an empty list when funding isn't configured.
  */
 export function useFundingChains(): UseFundingChains {
-  const { uiConfig } = useOpenfort()
+  const { uiConfig, publishableKey } = useOpenfort()
   // Defaults to the SDK backend (api.openfort.io); override for a custom funding service.
   const baseUrl = uiConfig.fundingBaseUrl || SDKConfiguration.getInstance()?.backendUrl || 'https://api.openfort.io'
   const sourceChains = uiConfig.funding?.sourceChains ?? DEFAULT_SOURCE_CHAINS
   const sourceCurrencies = uiConfig.funding?.sourceCurrencies ?? DEFAULT_SOURCE_CURRENCIES
-  const [state, setState] = useState<UseFundingChains>({ chains: [], loading: true, error: null })
+  // Match the rail host to the key environment: test keys (`pk_test_…`) list the
+  // testnet rail, everything else the mainnet rail. The backend picks the same
+  // host from the request livemode for the authenticated session endpoints.
+  const livemode = getPublishableKeyEnvironment(publishableKey) !== 'test'
+  const [state, setState] = useState<{ chains: FundingChain[]; loading: boolean; error: Error | null }>({
+    chains: [],
+    loading: true,
+    error: null,
+  })
 
   useEffect(() => {
     let cancelled = false
     setState((s) => ({ ...s, loading: true }))
-    fetch(`${baseUrl}/v2/funding/chains`)
+    fetch(`${baseUrl}/v2/funding/chains?livemode=${livemode}`)
       .then((r) => {
         if (!r.ok) throw new Error(`Failed to load chains (${r.status})`)
         return r.json() as Promise<{ chains: FundingChain[] }>
@@ -87,10 +102,15 @@ export function useFundingChains(): UseFundingChains {
     return () => {
       cancelled = true
     }
-  }, [baseUrl])
+  }, [baseUrl, livemode])
 
   // Narrow the provider dictionary to the selected subset (cheap, O(chains)).
-  return { ...state, chains: curateChains(state.chains, sourceChains, sourceCurrencies) }
+  return {
+    chains: curateChains(state.chains, sourceChains, sourceCurrencies),
+    railChains: state.chains,
+    loading: state.loading,
+    error: state.error,
+  }
 }
 
 /**

--- a/packages/openfort-react/src/shared/utils/explorer.ts
+++ b/packages/openfort-react/src/shared/utils/explorer.ts
@@ -53,19 +53,19 @@ type ExplorerUrlBuilder = (options: ExplorerUrlOptions) => string
 
 const explorerRegistry: Record<ChainTypeEnum, ExplorerUrlBuilder> = {
   [ChainTypeEnum.EVM]: (options) => {
+    // Never fall back to an unrelated chain's explorer — a valid hash on the wrong
+    // explorer reads as "transaction not found". Return '' so callers hide the link.
     if (!options.chainId) {
-      logger.warn(
-        'No chain ID provided. Configure explorerUrls in OpenfortProvider for better reliability and rate limits.'
-      )
-      return polygonAmoy.blockExplorers.default.url
+      logger.warn('No chain ID provided; cannot build an explorer URL for this transaction.')
+      return ''
     }
     const chain = EVM_CHAINS_BY_ID[options.chainId as keyof typeof EVM_CHAINS_BY_ID]
     const explorerUrl = chain?.blockExplorers?.default.url
     if (!explorerUrl) {
       logger.warn(
-        `No explorer URL found for chain ${options.chainId}. Configure explorerUrls in OpenfortProvider for better reliability and rate limits.`
+        `No explorer URL known for chain ${options.chainId}. Configure explorerUrls in OpenfortProvider to enable the link.`
       )
-      return polygonAmoy.blockExplorers.default.url
+      return ''
     }
     return appendPath(explorerUrl, options)
   },


### PR DESCRIPTION
  ## What

  Adds testnet funding to the deposit widget and fixes related display bugs.

  - **Livemode-aware rail** — `pk_test_…` keys hit Relay's testnet host and target
    native ETH (Base Sepolia / Sepolia); live keys unchanged.
  - **Testnet UX** — collapsible notice explaining testnet limits (links Relay's
    testnet guide); CEX + card/Apple Pay options disabled on testnet with a reason.
  - **Unsupported networks** — when a target chain isn't on the rail, show a notice
    plus a switcher to the supported chains (rail ∩ Openfort).
  - **Same-chain deposits** — no rail session exists, so arrival is detected from a
    native-balance increase (backoff poll, refetch on tab return) → success screen.
  - **Testnet assets** — the ERC-7811 proxy indexes mainnet only, so the single-chain
    asset path now reads the testnet native straight from RPC (matches the
    multi-chain inventory); fixes a false "No assets available".
  - **Logos** — curated chain/currency logos replace the rail's inconsistent testnet
    icons, with a colored-monogram fallback so the QR centre is never blank.
  - **Explorer link** — no longer falls back to a wrong chain's explorer.

  ## Depends on

  API testnet-funding endpoint (livemode-aware `/v2/funding/chains` + receiver),
  shipped separately on `feat/implement-testnet-funding`.

  ## Testing

  `pnpm check` · `check:types` · `check:unused` · `check:audit` all green;
  219/219 unit tests pass; prod build clean.