### PR TITLE
feat(solana): match EVM chain selector styling in connected header

### DIFF
--- a/.changeset/solana-chain-selector-evm-parity.md
+++ b/.changeset/solana-chain-selector-evm-parity.md
@@ -1,0 +1,5 @@
+---
+"@openfort/react": patch
+---
+
+Solana connected header: render the network indicator with the same pill button and tooltip as the EVM chain selector (single-network state) instead of a bespoke badge, so EVM and Solana headers stay visually consistent. The EVM `SwitchChainButton` is now a shared component. The cluster remains fixed by `walletConfig.solana`, so the Solana indicator stays read-only (no chevron or dropdown).

--- a/packages/openfort-react/src/components/Common/Chain/styles.ts
+++ b/packages/openfort-react/src/components/Common/Chain/styles.ts
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion'
 import { css, keyframes } from 'styled-components'
+import defaultTheme from '../../../constants/defaultTheme'
 import styled from '../../../styles/styled'
 
 type ChainContainerProps = {
@@ -98,4 +99,107 @@ export const Unsupported = styled(motion.div)`
     top: -30%;
     right: -30%;
   }
+`
+
+/**
+ * Pill-shaped chain indicator/switch button shown in the connected header.
+ *
+ * Shared by the EVM `ChainSelect` (which adds a chevron + dropdown when more
+ * than one chain is available) and the read-only Solana indicator (which always
+ * renders in the `disabled` single-network state). The `disabled` branch
+ * collapses to an icon-only badge and shifts left to keep the icon aligned with
+ * the enabled pill.
+ */
+export const SwitchChainButton = styled(motion.button)`
+  --color: var(
+    --ck-dropdown-button-color,
+    var(--ck-button-primary-color, var(--ck-body-color))
+  );
+  --background: var(
+    --ck-dropdown-button-background,
+    var(--ck-secondary-button-background, var(--ck-body-background-secondary))
+  );
+  --box-shadow: var(
+    --ck-dropdown-button-box-shadow,
+    var(
+      --ck-secondary-button-box-shadow,
+      var(--ck-button-primary-box-shadow),
+      none
+    )
+  );
+
+  --hover-color: var(--ck-dropdown-button-hover-color, var(--color));
+  --hover-background: var(
+    --ck-dropdown-button-hover-background,
+    var(--background)
+  );
+  --hover-box-shadow: var(
+    --ck-dropdown-button-hover-box-shadow,
+    var(--box-shadow)
+  );
+
+  --active-color: var(--ck-dropdown-button-active-color, var(--hover-color));
+  --active-background: var(
+    --ck-dropdown-button-active-background,
+    var(--hover-background)
+  );
+  --active-box-shadow: var(
+    --ck-dropdown-button-active-box-shadow,
+    var(--hover-box-shadow)
+  );
+
+  appearance: none;
+  user-select: none;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 15px;
+  width: 52px;
+  height: 30px;
+  padding: 2px 6px 2px 3px;
+  font-size: 16px;
+  line-height: 19px;
+  font-weight: 500;
+  text-decoration: none;
+  white-space: nowrap;
+  transform: translateZ(0px);
+
+  transition: 100ms ease;
+  transition-property: transform, background-color, box-shadow, color;
+
+  color: var(--color);
+  background: var(--background);
+  box-shadow: var(--box-shadow);
+
+  svg {
+    position: relative;
+    display: block;
+  }
+
+  ${(props) =>
+    props.disabled
+      ? css`
+          width: auto;
+          padding: 3px;
+          position: relative;
+          left: -22px;
+        `
+      : css`
+          cursor: pointer;
+
+          @media only screen and (min-width: ${defaultTheme.mobileWidth + 1}px) {
+            &:hover,
+            &:focus-visible {
+              color: var(--hover-color);
+              background: var(--hover-background);
+              box-shadow: var(--hover-box-shadow);
+            }
+            &:active {
+              color: var(--active-color);
+              background: var(--active-background);
+              box-shadow: var(--active-box-shadow);
+            }
+          }
+        `}
 `

--- a/packages/openfort-react/src/components/Common/SolanaChain/index.tsx
+++ b/packages/openfort-react/src/components/Common/SolanaChain/index.tsx
@@ -2,7 +2,7 @@
 
 import Logos from '../../../assets/logos'
 import { useSolanaContext } from '../../../solana/SolanaContext'
-import styled from '../../../styles/styled'
+import { ChainContainer, LogoContainer, SwitchChainButton } from '../Chain/styles'
 import Tooltip from '../Tooltip'
 
 /** `mainnet-beta` → "Mainnet"; otherwise capitalize the cluster name. */
@@ -12,34 +12,32 @@ function formatCluster(cluster?: string): string {
   return cluster.charAt(0).toUpperCase() + cluster.slice(1)
 }
 
-const Badge = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: #131313;
-  border: 2px solid var(--ck-body-background, #fff);
-  box-sizing: border-box;
-`
+/** Solana mark rendered in the same circular container as the EVM `Chain` icon. */
+const SolanaChainIcon = () => (
+  <ChainContainer size={24} radius="50%">
+    <LogoContainer initial={false} animate={{ opacity: 1 }}>
+      <Logos.Solana style={{ width: '62%', height: 'auto' }} />
+    </LogoContainer>
+  </ChainContainer>
+)
 
 /**
- * Read-only Solana network indicator for the Connected modal — the Solana logo,
- * with the active cluster shown on hover. There is no switch: the cluster is
- * fixed by `walletConfig.solana`, and switching between Solana and EVM is
- * intentionally unsupported.
+ * Read-only Solana network indicator for the Connected modal. Mirrors the EVM
+ * `ChainSelect` in its single-network (`disabled`) state — the same pill button
+ * and tooltip — so EVM and Solana headers stay visually consistent. There is no
+ * switch: the cluster is fixed by `walletConfig.solana` and cannot change at
+ * runtime, so the button never gains a chevron or dropdown.
  */
 const SolanaChain = () => {
   const cluster = useSolanaContext()?.cluster
   const label = cluster ? `Solana · ${formatCluster(cluster)}` : 'Solana'
 
   return (
-    <Tooltip message={label}>
-      <Badge aria-label={label}>
-        <Logos.Solana style={{ width: '62%', height: 'auto' }} />
-      </Badge>
-    </Tooltip>
+    <SwitchChainButton type="button" disabled aria-label={label}>
+      <Tooltip message={label} xOffset={-6} delay={0.01}>
+        <SolanaChainIcon />
+      </Tooltip>
+    </SwitchChainButton>
   )
 }
 

--- a/packages/openfort-react/src/wagmi/components/ChainSelect/index.tsx
+++ b/packages/openfort-react/src/wagmi/components/ChainSelect/index.tsx
@@ -3,9 +3,9 @@
 import { motion } from 'framer-motion'
 import type React from 'react'
 import { useEffect, useState } from 'react'
-import { css } from 'styled-components'
 import { useChainId } from 'wagmi'
 import Chain from '../../../components/Common/Chain'
+import { SwitchChainButton } from '../../../components/Common/Chain/styles'
 import Tooltip from '../../../components/Common/Tooltip'
 import { routes } from '../../../components/Openfort/types'
 import { useOpenfort } from '../../../components/Openfort/useOpenfort'
@@ -17,100 +17,6 @@ import { useSwitchChainFiltered } from '../../useSwitchChainFiltered'
 import ChainSelectDropdown from '../ChainSelectDropdown'
 
 const Container = styled(motion.div)``
-
-const SwitchChainButton = styled(motion.button)`
-  --color: var(
-    --ck-dropdown-button-color,
-    var(--ck-button-primary-color, var(--ck-body-color))
-  );
-  --background: var(
-    --ck-dropdown-button-background,
-    var(--ck-secondary-button-background, var(--ck-body-background-secondary))
-  );
-  --box-shadow: var(
-    --ck-dropdown-button-box-shadow,
-    var(
-      --ck-secondary-button-box-shadow,
-      var(--ck-button-primary-box-shadow),
-      none
-    )
-  );
-
-  --hover-color: var(--ck-dropdown-button-hover-color, var(--color));
-  --hover-background: var(
-    --ck-dropdown-button-hover-background,
-    var(--background)
-  );
-  --hover-box-shadow: var(
-    --ck-dropdown-button-hover-box-shadow,
-    var(--box-shadow)
-  );
-
-  --active-color: var(--ck-dropdown-button-active-color, var(--hover-color));
-  --active-background: var(
-    --ck-dropdown-button-active-background,
-    var(--hover-background)
-  );
-  --active-box-shadow: var(
-    --ck-dropdown-button-active-box-shadow,
-    var(--hover-box-shadow)
-  );
-
-  appearance: none;
-  user-select: none;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border-radius: 15px;
-  width: 52px;
-  height: 30px;
-  padding: 2px 6px 2px 3px;
-  font-size: 16px;
-  line-height: 19px;
-  font-weight: 500;
-  text-decoration: none;
-  white-space: nowrap;
-  transform: translateZ(0px);
-
-  transition: 100ms ease;
-  transition-property: transform, background-color, box-shadow, color;
-
-  color: var(--color);
-  background: var(--background);
-  box-shadow: var(--box-shadow);
-
-  svg {
-    position: relative;
-    display: block;
-  }
-
-  ${(props) =>
-    props.disabled
-      ? css`
-          width: auto;
-          padding: 3px;
-          position: relative;
-          left: -22px;
-        `
-      : css`
-          cursor: pointer;
-
-          @media only screen and (min-width: ${defaultTheme.mobileWidth + 1}px) {
-            &:hover,
-            &:focus-visible {
-              color: var(--hover-color);
-              background: var(--hover-background);
-              box-shadow: var(--hover-box-shadow);
-            }
-            &:active {
-              color: var(--active-color);
-              background: var(--active-background);
-              box-shadow: var(--active-box-shadow);
-            }
-          }
-        `}
-`
 
 const ChevronDown = ({ ...props }) => (
   <svg


### PR DESCRIPTION
## What

The Solana connected-modal header used a bespoke read-only badge for the network indicator, while EVM uses the `ChainSelect` pill button. This makes the Solana indicator render with the **exact** EVM button styling in its single-network state, so the two headers are visually consistent.

## Changes

- **Extract `SwitchChainButton`** into `components/Common/Chain/styles.ts` as a shared styled-component. The EVM `ChainSelect` now imports it instead of defining it locally — no EVM behavior change (it still adds the chevron + dropdown when 2+ chains are available).
- **`SolanaChain`** now renders the shared `SwitchChainButton` in its `disabled` (single-network) state, wrapping a Solana mark in a `Tooltip` (`Solana · <Cluster>`), mirroring EVM's disabled branch (same `xOffset`/`delay`, same left-shift alignment).
- The Solana mark now renders inside the theme-aware `ChainContainer`/`LogoContainer` used by the EVM `Chain` icon, replacing the hardcoded `#131313` badge.

The cluster is fixed by `walletConfig.solana` and cannot change at runtime, so the Solana indicator stays read-only — no chevron, no dropdown.

## Notes

EVM's disabled `SwitchChainButton` also wraps its `Tooltip`; a `disabled` `<button>` can suppress pointer events in some browsers, which may swallow tooltip hover. Solana now shares this exact behavior — if it ever needs fixing, the fix applies to the shared button for both.

## Verification

- `biome check` on changed files — clean (pre-commit hook passed)
- `pnpm check:types` — no errors from project `src`
- Chain test suites (`curateChains`, `switchChainGate`, `embeddedConnector.switchChain`) — 17/17 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)