### PR TITLE
feat(useUI): add deep-link navigation helpers

### DIFF
--- a/.changeset/useui-deep-link-navigation.md
+++ b/.changeset/useui-deep-link-navigation.md
@@ -1,0 +1,5 @@
+---
+"@openfort/react": minor
+---
+
+useUI: add deep-link navigation helpers (openSend, openReceive, openFunding, openBuy, openExportKey, openSettings) so callers can open a specific wallet screen directly. Each targets a connected-only screen and falls back to the login screen when the user is not connected.

--- a/packages/openfort-react/src/__tests__/hooks/useUI.gotoAndOpen.test.tsx
+++ b/packages/openfort-react/src/__tests__/hooks/useUI.gotoAndOpen.test.tsx
@@ -13,7 +13,11 @@ import { routes } from '../../components/Openfort/types'
  * reset-on-open semantics so the wrong call order fails the test.
  */
 
-const state: { route: { route: string }; open: boolean } = { route: { route: routes.LOADING }, open: false }
+const state: { route: { route: string }; open: boolean; connected: boolean } = {
+  route: { route: routes.LOADING },
+  open: false,
+  connected: false,
+}
 
 const setRoute = vi.fn((r: string | { route: string }) => {
   state.route = typeof r === 'string' ? { route: r } : r
@@ -47,10 +51,10 @@ vi.mock('../../openfort/useOpenfort', () => ({
 vi.mock('../../core/ConnectionStrategyContext', () => ({ useConnectionStrategy: () => null }))
 vi.mock('../../ethereum/OpenfortEthereumBridgeContext', () => ({ useEthereumBridge: () => null }))
 vi.mock('../../ethereum/hooks/useEthereumEmbeddedWallet', () => ({
-  useEthereumEmbeddedWallet: () => ({ status: 'disconnected' }),
+  useEthereumEmbeddedWallet: () => ({ status: state.connected ? 'connected' : 'disconnected' }),
 }))
 vi.mock('../../solana/hooks/useSolanaEmbeddedWallet', () => ({
-  useSolanaEmbeddedWallet: () => ({ status: 'disconnected' }),
+  useSolanaEmbeddedWallet: () => ({ status: state.connected ? 'connected' : 'disconnected' }),
 }))
 
 const { useUI } = await import('../../hooks/openfort/useUI')
@@ -59,6 +63,7 @@ describe('useUI gotoAndOpen', () => {
   beforeEach(() => {
     state.route = { route: routes.LOADING }
     state.open = false
+    state.connected = false
     vi.clearAllMocks()
   })
 
@@ -79,5 +84,43 @@ describe('useUI gotoAndOpen', () => {
 
     expect(state.open).toBe(true)
     expect(state.route).toMatchObject({ route: routes.PROVIDERS })
+  })
+
+  it('deep-link helpers fall back to PROVIDERS while disconnected', () => {
+    const { result } = renderHook(() => useUI())
+
+    // Connected-only destinations route the user through login first.
+    for (const open of [
+      result.current.openSend,
+      result.current.openReceive,
+      result.current.openFunding,
+      result.current.openBuy,
+      result.current.openExportKey,
+      result.current.openSettings,
+    ]) {
+      act(() => open())
+      expect(state.open).toBe(true)
+      expect(state.route).toMatchObject({ route: routes.PROVIDERS })
+    }
+  })
+
+  it('deep-link helpers navigate to their target route while connected', () => {
+    state.connected = true
+    const { result } = renderHook(() => useUI())
+
+    const cases: [() => void, string][] = [
+      [result.current.openSend, routes.SEND],
+      [result.current.openReceive, routes.RECEIVE],
+      [result.current.openFunding, routes.DEPOSIT],
+      [result.current.openBuy, routes.BUY],
+      [result.current.openExportKey, routes.EXPORT_KEY],
+      [result.current.openSettings, routes.PROFILE],
+    ]
+
+    for (const [open, route] of cases) {
+      act(() => open())
+      expect(state.open).toBe(true)
+      expect(state.route).toMatchObject({ route })
+    }
   })
 })

--- a/packages/openfort-react/src/hooks/openfort/useUI.ts
+++ b/packages/openfort-react/src/hooks/openfort/useUI.ts
@@ -27,6 +27,12 @@ const safeRoutes: {
     { route: routes.CONNECTORS, connectType: 'linkIfUserConnectIfNoUser' },
     routes.ETH_SWITCH_NETWORK,
     routes.PROVIDERS,
+    routes.PROFILE,
+    routes.SEND,
+    routes.RECEIVE,
+    routes.DEPOSIT,
+    routes.BUY,
+    routes.EXPORT_KEY,
   ],
 }
 
@@ -63,8 +69,14 @@ function isAccountId(id: string): boolean {
  *
  * ui.open(); // Opens modal with default route
  * ui.close(); // Closes modal
- * ui.openProfile(); // Opens user profile screen
+ * ui.openProfile(); // Opens the connected wallet overview
+ * ui.openSend(); // Opens the Send flow
+ * ui.openFunding(); // Opens the Deposit (funding) hub
  * ```
+ *
+ * The `open*` navigation helpers target connected-only screens. When called while
+ * the user is not connected they fall back to the login screen, so a caller can
+ * fire them directly and let the modal route the user through auth first.
  */
 export function useUI() {
   const { open, setOpen, setRoute, setConnector, connector, chainType } = useOpenfort()
@@ -132,5 +144,12 @@ export function useUI() {
     openSwitchNetworks: () => gotoAndOpen(routes.ETH_SWITCH_NETWORK),
     openProviders: () => gotoAndOpen(routes.PROVIDERS),
     openWallets: () => gotoAndOpen({ route: routes.CONNECTORS, connectType: 'linkIfUserConnectIfNoUser' }),
+
+    openSend: () => gotoAndOpen(routes.SEND),
+    openReceive: () => gotoAndOpen(routes.RECEIVE),
+    openFunding: () => gotoAndOpen(routes.DEPOSIT),
+    openBuy: () => gotoAndOpen(routes.BUY),
+    openExportKey: () => gotoAndOpen(routes.EXPORT_KEY),
+    openSettings: () => gotoAndOpen(routes.PROFILE),
   }
 }


### PR DESCRIPTION
## What

Adds six navigation helpers to `useUI()` so callers can open a specific wallet screen directly:

- `openSend()` → Send
- `openReceive()` → Receive
- `openFunding()` → Deposit (funding) hub
- `openBuy()` → Buy (on-ramp)
- `openExportKey()` → Export private key
- `openSettings()` → Profile/settings

Each routes through the existing `gotoAndOpen()` allowlist (the six routes are added to `safeRoutes.connected`). They target connected-only screens, so calling one while the user is disconnected falls back to the login screen — a caller can fire it directly and let the modal route the user through auth first.

## Why

`useUI()` exposed `open/openProfile/openWallets/openProviders/openSwitchNetworks` but no way to deep-link into Send, Deposit, etc. The docs UI configuration page uses these to drive a live wallet demo from "Try it" buttons.

## Tests

`useUI.gotoAndOpen.test.tsx` extended: the new helpers fall back to PROVIDERS while disconnected, and navigate to their target route while connected. Full package suite green (221 tests). Changeset included (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)