### PR TITLE
feat(send): standardize EVM/Solana confirmation + openSend(tx) preview

### DIFF
--- a/.changeset/send-confirmation-standardize.md
+++ b/.changeset/send-confirmation-standardize.md
@@ -1,0 +1,5 @@
+---
+"@openfort/react": minor
+---
+
+Standardize the send confirmation screen across EVM and Solana with a shared approval-style preview (Total / To / Network / Estimated fee + a "Pay with" card; sponsored sends show a gasless fee). `useUI().openSend(tx)` now accepts a prepared transaction (`{ to, amount, asset? }`) and jumps straight to that preview, skipping asset/amount/recipient entry; `openSend()` with no arguments still opens the full send flow.

--- a/packages/openfort-react/src/__tests__/pages/SolanaSendConfirmation.test.tsx
+++ b/packages/openfort-react/src/__tests__/pages/SolanaSendConfirmation.test.tsx
@@ -121,6 +121,6 @@ describe('SolanaSendConfirmation', () => {
   it('shows the Sponsored network-fee row only when sponsorFees is on', () => {
     h.sponsorFees = true
     render(<SolanaSendConfirmation />)
-    expect(screen.getByText('Sponsored')).toBeTruthy()
+    expect(screen.getByText(/Sponsored/)).toBeTruthy()
   })
 })

--- a/packages/openfort-react/src/components/Pages/SendConfirmation/ConfirmationSummary.tsx
+++ b/packages/openfort-react/src/components/Pages/SendConfirmation/ConfirmationSummary.tsx
@@ -16,7 +16,7 @@ import {
   SummaryList,
 } from './styles'
 
-export type ConfirmationAddress = { display: string; value: string }
+type ConfirmationAddress = { display: string; value: string }
 
 interface ConfirmationSummaryProps {
   /** Total being sent, e.g. "0.5" + "ETH". */

--- a/packages/openfort-react/src/components/Pages/SendConfirmation/ConfirmationSummary.tsx
+++ b/packages/openfort-react/src/components/Pages/SendConfirmation/ConfirmationSummary.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { CopyText } from '../../Common/CopyToClipboard/CopyText'
+import {
+  AddressValue,
+  AmountValue,
+  FiatValue,
+  NetworkValue,
+  PayWithAddress,
+  PayWithBadge,
+  PayWithCard,
+  PayWithMeta,
+  SummaryItem,
+  SummaryLabel,
+  SummaryList,
+} from './styles'
+
+export type ConfirmationAddress = { display: string; value: string }
+
+interface ConfirmationSummaryProps {
+  /** Total being sent, e.g. "0.5" + "ETH". */
+  amount: string
+  symbol: string
+  /** Optional fiat estimate shown next to the total, e.g. "$180.84". */
+  fiat?: string | null
+  /** Recipient address (truncated for display, full for copy). */
+  to?: ConfirmationAddress
+  networkName: string
+  networkIcon?: ReactNode
+  /** Fee cell — the live estimate, or a "Sponsored" indicator. */
+  fee: ReactNode
+  /** The wallet the funds are paid from. */
+  payWith?: ConfirmationAddress
+}
+
+/**
+ * Shared, chain-agnostic transaction preview used by the EVM and Solana send
+ * confirmation screens. Renders the approval-style rows (Total / To / Network /
+ * Estimated fee) plus a "Pay with" card.
+ */
+export function ConfirmationSummary({
+  amount,
+  symbol,
+  fiat,
+  to,
+  networkName,
+  networkIcon,
+  fee,
+  payWith,
+}: ConfirmationSummaryProps) {
+  return (
+    <>
+      <SummaryList>
+        <SummaryItem>
+          <SummaryLabel>Total</SummaryLabel>
+          <AmountValue>
+            {amount || '0'} {symbol}
+            {fiat ? <FiatValue>≈ {fiat}</FiatValue> : null}
+          </AmountValue>
+        </SummaryItem>
+
+        <SummaryItem>
+          <SummaryLabel>To</SummaryLabel>
+          <AddressValue>
+            {to ? (
+              <CopyText size="1rem" value={to.value}>
+                {to.display}
+              </CopyText>
+            ) : (
+              '--'
+            )}
+          </AddressValue>
+        </SummaryItem>
+
+        <SummaryItem>
+          <SummaryLabel>Network</SummaryLabel>
+          <NetworkValue>
+            {networkIcon}
+            {networkName}
+          </NetworkValue>
+        </SummaryItem>
+
+        <SummaryItem>
+          <SummaryLabel>Estimated fee</SummaryLabel>
+          {fee}
+        </SummaryItem>
+      </SummaryList>
+
+      <PayWithCard>
+        <PayWithMeta>
+          <SummaryLabel>Pay with</SummaryLabel>
+          <PayWithAddress>
+            {payWith ? (
+              <CopyText size="0.875rem" value={payWith.value}>
+                {payWith.display}
+              </CopyText>
+            ) : (
+              '--'
+            )}
+          </PayWithAddress>
+        </PayWithMeta>
+        <PayWithBadge>
+          {amount || '0'} {symbol}
+        </PayWithBadge>
+      </PayWithCard>
+    </>
+  )
+}

--- a/packages/openfort-react/src/components/Pages/SendConfirmation/SolanaSendConfirmation.tsx
+++ b/packages/openfort-react/src/components/Pages/SendConfirmation/SolanaSendConfirmation.tsx
@@ -18,24 +18,13 @@ import { useSolanaEmbeddedWallet } from '../../../solana/hooks/useSolanaEmbedded
 import { sendSol, sendSolGasless, sendSplToken, sendSplTokenGasless } from '../../../solana/transfer'
 import { truncateSolanaAddress } from '../../../utils'
 import Button from '../../Common/Button'
-import { CopyText } from '../../Common/CopyToClipboard/CopyText'
 import Loader from '../../Common/Loading'
 import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
 import { routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
-import {
-  AddressValue,
-  AmountValue,
-  ButtonRow,
-  ErrorContainer,
-  ErrorMessage,
-  ErrorTitle,
-  FeesValue,
-  SummaryItem,
-  SummaryLabel,
-  SummaryList,
-} from './styles'
+import { ConfirmationSummary } from './ConfirmationSummary'
+import { ButtonRow, ErrorContainer, ErrorMessage, ErrorTitle, FeesValue, SponsoredFee } from './styles'
 
 const SOL_DECIMALS = 9
 
@@ -154,46 +143,16 @@ export const SolanaSendConfirmation = () => {
   return (
     <PageContent onBack={routes.SOL_SEND}>
       <ModalHeading>Confirm transfer</ModalHeading>
-      <ModalBody>Review the transaction details before sending.</ModalBody>
+      <ModalBody>Review the transaction before sending.</ModalBody>
 
-      <SummaryList>
-        <SummaryItem>
-          <SummaryLabel>Sending</SummaryLabel>
-          <AmountValue>
-            {amount || '0'} {symbol}
-          </AmountValue>
-        </SummaryItem>
-        <SummaryItem>
-          <SummaryLabel>From</SummaryLabel>
-          <AddressValue>
-            {address ? (
-              <CopyText size="1rem" value={address}>
-                {truncateSolanaAddress(address)}
-              </CopyText>
-            ) : (
-              '--'
-            )}
-          </AddressValue>
-        </SummaryItem>
-        <SummaryItem>
-          <SummaryLabel>To</SummaryLabel>
-          <AddressValue>
-            {recipient ? (
-              <CopyText size="1rem" value={recipient}>
-                {truncateSolanaAddress(recipient)}
-              </CopyText>
-            ) : (
-              '--'
-            )}
-          </AddressValue>
-        </SummaryItem>
-        {isSponsored && (
-          <SummaryItem>
-            <SummaryLabel>Network fee</SummaryLabel>
-            <FeesValue $completed>Sponsored</FeesValue>
-          </SummaryItem>
-        )}
-      </SummaryList>
+      <ConfirmationSummary
+        amount={amount || '0'}
+        symbol={symbol}
+        to={recipient ? { display: truncateSolanaAddress(recipient), value: recipient } : undefined}
+        networkName={`Solana ${cluster.charAt(0).toUpperCase()}${cluster.slice(1)}`}
+        payWith={address ? { display: truncateSolanaAddress(address), value: address } : undefined}
+        fee={isSponsored ? <SponsoredFee>Sponsored · gasless</SponsoredFee> : <FeesValue>Network fee</FeesValue>}
+      />
 
       {error && (
         <ErrorContainer>

--- a/packages/openfort-react/src/components/Pages/SendConfirmation/index.tsx
+++ b/packages/openfort-react/src/components/Pages/SendConfirmation/index.tsx
@@ -23,28 +23,23 @@ import { parseTransactionError } from '../../../utils/errorHandling'
 import { logger } from '../../../utils/logger'
 import { getChainName, getDefaultEthereumRpcUrl } from '../../../utils/rpc'
 import Button from '../../Common/Button'
-import { CopyText } from '../../Common/CopyToClipboard/CopyText'
 import Loader from '../../Common/Loading'
 import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
 import { routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
 import { getAssetDecimals, getAssetSymbol, isSameToken, sanitizeForParsing } from '../Send/utils'
+import { ConfirmationSummary } from './ConfirmationSummary'
 import { EstimatedFees } from './EstimatedFees'
 import {
-  AddressValue,
-  AmountValue,
   ButtonRow,
-  CheckIconWrapper,
   ErrorAction,
   ErrorContainer,
   ErrorMessage,
   ErrorTitle,
   FeesValue,
+  SponsoredFee,
   StatusMessage,
-  SummaryItem,
-  SummaryLabel,
-  SummaryList,
 } from './styles'
 
 /** Check if chain is a testnet */
@@ -383,6 +378,13 @@ const SendConfirmation = () => {
     return feeSponsorship[chainId ?? 0] !== undefined
   }, [walletConfig?.ethereum?.ethereumFeeSponsorshipId, chainId])
 
+  const fiatTotal = useMemo(() => {
+    const perToken = token.metadata?.fiat?.value
+    const n = Number(normalisedAmount)
+    if (!perToken || !Number.isFinite(n) || n <= 0) return null
+    return `$${(n * perToken).toFixed(2)}`
+  }, [token.metadata?.fiat?.value, normalisedAmount])
+
   if (isSuccess) {
     const successAmount = normalisedAmount || '0'
     const successSymbol = getAssetSymbol(token)
@@ -406,46 +408,20 @@ const SendConfirmation = () => {
   return (
     <PageContent>
       <ModalHeading>Confirm transfer</ModalHeading>
-      <ModalBody>Review the transaction details before sending.</ModalBody>
+      <ModalBody>Review the transaction before sending.</ModalBody>
 
-      <SummaryList>
-        <SummaryItem>
-          <SummaryLabel>Sending</SummaryLabel>
-          <AmountValue>
-            {normalisedAmount || '0'} {getAssetSymbol(token)}
-          </AmountValue>
-        </SummaryItem>
-
-        <SummaryItem>
-          <SummaryLabel>From</SummaryLabel>
-          <AddressValue>
-            {address ? (
-              <CopyText size="1rem" value={address}>
-                {truncateEthAddress(address)}
-              </CopyText>
-            ) : (
-              '--'
-            )}
-          </AddressValue>
-        </SummaryItem>
-
-        <SummaryItem>
-          <SummaryLabel>To</SummaryLabel>
-          <AddressValue>
-            {recipientAddress ? (
-              <CopyText size="1rem" value={recipientAddress}>
-                {truncateEthAddress(recipientAddress)}
-              </CopyText>
-            ) : (
-              '--'
-            )}
-          </AddressValue>
-        </SummaryItem>
-
-        <div>
-          <SummaryItem>
-            <SummaryLabel>Estimated fees</SummaryLabel>
-            <FeesValue $completed={isSponsored}>
+      <ConfirmationSummary
+        amount={normalisedAmount || '0'}
+        symbol={getAssetSymbol(token)}
+        fiat={fiatTotal}
+        to={recipientAddress ? { display: truncateEthAddress(recipientAddress), value: recipientAddress } : undefined}
+        networkName={getChainName(chainId ?? 0)}
+        payWith={address ? { display: truncateEthAddress(address), value: address } : undefined}
+        fee={
+          isSponsored ? (
+            <SponsoredFee>Sponsored · gasless</SponsoredFee>
+          ) : (
+            <FeesValue>
               <EstimatedFees
                 account={address}
                 to={token.type === 'erc20' ? (token.address as `0x${string}`) : recipientAddress}
@@ -454,28 +430,12 @@ const SendConfirmation = () => {
                 chainId={chainId}
                 nativeSymbol={nativeSymbol}
                 enabled={Boolean(address && recipientAddress && parsedAmount && parsedAmount > BigInt(0))}
-                hideInfoIcon={isSponsored}
+                hideInfoIcon={false}
               />
-              <CheckIconWrapper>
-                <TickIcon />
-              </CheckIconWrapper>
             </FeesValue>
-          </SummaryItem>
-          {isSponsored && (
-            <div
-              style={{
-                textAlign: 'end',
-                marginTop: '4px',
-                width: '100%',
-                color: 'var(--ck-body-color-valid)',
-                fontSize: '12px',
-              }}
-            >
-              Sponsored transaction
-            </div>
-          )}
-        </div>
-      </SummaryList>
+          )
+        }
+      />
 
       {insufficientBalance && !isSuccess && (
         <StatusMessage $status="error">Insufficient balance for this transfer.</StatusMessage>

--- a/packages/openfort-react/src/components/Pages/SendConfirmation/styles.ts
+++ b/packages/openfort-react/src/components/Pages/SendConfirmation/styles.ts
@@ -111,29 +111,6 @@ export const PayWithBadge = styled.span`
   background: var(--ck-body-background, rgba(22, 163, 74, 0.12));
 `
 
-export const CheckIconWrapper = styled.span`
-  color: var(--ck-body-color);
-  line-height: 0;
-  display: inline-flex;
-  align-items: center;
-  
-  svg {
-    width: 16px;
-    height: 16px;
-  }
-`
-
-// export const BalanceSpinnerWrapper = styled.span`
-//   display: inline-flex;
-//   align-items: center;
-//   margin-left: 8px;
-
-//   svg {
-//     width: 14px;
-//     height: 14px;
-//   }
-// `
-
 export const InfoIconWrapper = styled.span`
   color: var(--ck-body-color-muted);
   opacity: 0.6;

--- a/packages/openfort-react/src/components/Pages/SendConfirmation/styles.ts
+++ b/packages/openfort-react/src/components/Pages/SendConfirmation/styles.ts
@@ -52,6 +52,65 @@ export const FeesValue = styled(SummaryValue)<{ $completed?: boolean }>`
   opacity: ${(props) => (props.$completed ? 0.6 : 1)};
 `
 
+export const FiatValue = styled.span`
+  margin-left: 6px;
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--ck-body-color-muted);
+`
+
+export const NetworkValue = styled(SummaryValue)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+
+  svg,
+  img {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+  }
+`
+
+export const SponsoredFee = styled(SummaryValue)`
+  color: var(--ck-body-color-valid, #16a34a);
+`
+
+export const PayWithCard = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 4px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: var(--ck-body-background-secondary, rgba(0, 0, 0, 0.04));
+`
+
+export const PayWithMeta = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: left;
+`
+
+export const PayWithAddress = styled.span`
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ck-body-color);
+`
+
+export const PayWithBadge = styled.span`
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ck-body-color-valid, #16a34a);
+  background: var(--ck-body-background, rgba(22, 163, 74, 0.12));
+`
+
 export const CheckIconWrapper = styled.span`
   color: var(--ck-body-color);
   line-height: 0;

--- a/packages/openfort-react/src/hooks/openfort/useUI.ts
+++ b/packages/openfort-react/src/hooks/openfort/useUI.ts
@@ -2,7 +2,7 @@
 
 import { ChainTypeEnum } from '@openfort/openfort-js'
 import React from 'react'
-import { type RouteOptions, type RoutesWithoutOptions, routes } from '../../components/Openfort/types'
+import { type Asset, type RouteOptions, type RoutesWithoutOptions, routes } from '../../components/Openfort/types'
 import { useOpenfort } from '../../components/Openfort/useOpenfort'
 import { useConnectionStrategy } from '../../core/ConnectionStrategyContext'
 import { useEthereumEmbeddedWallet } from '../../ethereum/hooks/useEthereumEmbeddedWallet'
@@ -79,7 +79,7 @@ function isAccountId(id: string): boolean {
  * fire them directly and let the modal route the user through auth first.
  */
 export function useUI() {
-  const { open, setOpen, setRoute, setConnector, connector, chainType } = useOpenfort()
+  const { open, setOpen, setRoute, setConnector, setSendForm, connector, chainType } = useOpenfort()
   const { isLoading, user, needsRecovery, embeddedAccounts, activeEmbeddedAddress, embeddedState } = useOpenfortCore()
   const bridge = useEthereumBridge()
   const strategy = useConnectionStrategy()
@@ -114,6 +114,16 @@ export function useUI() {
     else setRoute(routes.CONNECTED)
   }
 
+  /**
+   * Prefill the send form and jump straight to the confirmation (preview) screen
+   * for the active chain, skipping asset/amount/recipient entry.
+   */
+  const openSendPreview = (tx: { to: string; amount: string; asset?: Asset }) => {
+    setSendForm({ recipient: tx.to, amount: tx.amount, asset: tx.asset ?? { type: 'native', balance: BigInt(0) } })
+    setOpen(true)
+    setRoute(chainType === ChainTypeEnum.SVM ? routes.SOL_SEND_CONFIRMATION : routes.SEND_CONFIRMATION)
+  }
+
   const gotoAndOpen = (route: ValidRoutes) => {
     const safeList = isConnected ? safeRoutes.connected : safeRoutes.disconnected
     const fallback = isConnected ? routes.CONNECTED : routes.PROVIDERS
@@ -145,7 +155,8 @@ export function useUI() {
     openProviders: () => gotoAndOpen(routes.PROVIDERS),
     openWallets: () => gotoAndOpen({ route: routes.CONNECTORS, connectType: 'linkIfUserConnectIfNoUser' }),
 
-    openSend: () => gotoAndOpen(routes.SEND),
+    openSend: (tx?: { to: string; amount: string; asset?: Asset }) =>
+      tx ? openSendPreview(tx) : gotoAndOpen(routes.SEND),
     openReceive: () => gotoAndOpen(routes.RECEIVE),
     openFunding: () => gotoAndOpen(routes.DEPOSIT),
     openBuy: () => gotoAndOpen(routes.BUY),


### PR DESCRIPTION
## What

Standardizes the send **confirmation/preview** across EVM and Solana into one approval-style layout, and adds a prepared-transaction entry point.

- **Shared `ConfirmationSummary`** (one source of truth, fed by thin EVM + Solana adapters): rows for **Total** (amount + fiat when known), **To**, **Network**, **Estimated fee**, plus a **"Pay with"** card. Sponsored sends show a **"Sponsored · gasless"** fee (from `ethereumFeeSponsorshipId` / `solana.sponsorFees`).
- **`useUI().openSend(tx)`** accepts a prepared transaction `{ to, amount, asset? }` and jumps straight to the confirmation/preview, skipping asset/amount/recipient entry. `openSend()` with no args still opens the full send flow.

## Verified

`pnpm --filter @openfort/react test` — 223 pass (incl. the EVM + Solana confirmation tests rendering the new layout). Build clean. Verified live: `openSend({ to, amount })` opens the approval-style preview (Total / To / Network / Estimated fee / Pay with). Changeset included (minor).

Follow-up: `useSendTransaction()` (promise-based) in a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)