### PR TITLE
fix(send/funding): anchor send form, compact amount UI, active-chain testnet check

### DIFF
--- a/packages/openfort-react/src/__tests__/useFundingTarget.test.ts
+++ b/packages/openfort-react/src/__tests__/useFundingTarget.test.ts
@@ -1,18 +1,29 @@
 import { ChainTypeEnum } from '@openfort/openfort-js'
 import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { DEST_CHAIN, DEST_CHAIN_SOL, DEST_USDC, DEST_USDC_SOL } from '../components/Pages/Deposit/sources'
+import {
+  DEST_CHAIN,
+  DEST_CHAIN_SOL,
+  DEST_USDC,
+  DEST_USDC_SOL,
+  NATIVE_TOKEN_ADDRESS,
+} from '../components/Pages/Deposit/sources'
 
-// useFundingTarget reads uiConfig.funding from useOpenfort and chainType from
-// useOpenfortCore. Stub both so we can drive the chain-aware default selection.
+// useFundingTarget reads uiConfig.funding from useOpenfort, chainType from
+// useOpenfortCore, and the active EVM chain from useEthereumEmbeddedWallet. Stub
+// all three so we can drive the chain-aware default selection.
 const mockUiConfig: { funding?: { targetChain?: string; targetCurrency?: string } } = {}
 let mockChainType: ChainTypeEnum = ChainTypeEnum.EVM
+let mockEthWallet: { status: string; chainId?: number } = { status: 'connected', chainId: 8453 }
 
 vi.mock('../components/Openfort/useOpenfort', () => ({
   useOpenfort: () => ({ uiConfig: mockUiConfig }),
 }))
 vi.mock('../openfort/useOpenfort', () => ({
   useOpenfortCore: () => ({ chainType: mockChainType }),
+}))
+vi.mock('../ethereum/hooks/useEthereumEmbeddedWallet', () => ({
+  useEthereumEmbeddedWallet: () => mockEthWallet,
 }))
 
 const { useFundingTarget } = await import('../components/Pages/Deposit/useFundingTarget')
@@ -21,9 +32,22 @@ describe('useFundingTarget', () => {
   beforeEach(() => {
     mockUiConfig.funding = undefined
     mockChainType = ChainTypeEnum.EVM
+    mockEthWallet = { status: 'connected', chainId: 8453 }
   })
 
-  it('defaults to USDC on Base for EVM wallets', () => {
+  it('defaults to USDC on the active EVM chain when it is Base', () => {
+    const { result } = renderHook(() => useFundingTarget())
+    expect(result.current).toEqual({ chain: DEST_CHAIN, currency: DEST_USDC })
+  })
+
+  it('defaults to native on the active EVM chain when it is not Base', () => {
+    mockEthWallet = { status: 'connected', chainId: 11155111 } // Sepolia
+    const { result } = renderHook(() => useFundingTarget())
+    expect(result.current).toEqual({ chain: 'eip155:11155111', currency: NATIVE_TOKEN_ADDRESS })
+  })
+
+  it('falls back to USDC on Base when the EVM wallet is not connected', () => {
+    mockEthWallet = { status: 'disconnected' }
     const { result } = renderHook(() => useFundingTarget())
     expect(result.current).toEqual({ chain: DEST_CHAIN, currency: DEST_USDC })
   })

--- a/packages/openfort-react/src/components/Pages/Buy/styles.ts
+++ b/packages/openfort-react/src/components/Pages/Buy/styles.ts
@@ -4,8 +4,8 @@ import { ButtonContainer } from '../../Common/Button/styles'
 export const Section = styled.div`
   display: flex;
   flex-direction: column;
-  margin-top: 20px;
-  gap: 12px;
+  margin-top: 16px;
+  gap: 10px;
 `
 
 export const SectionLabel = styled.span`
@@ -18,9 +18,9 @@ export const SectionLabel = styled.span`
 
 export const AmountCard = styled.div`
   display: flex;
-  align-items: baseline;
-  gap: 12px;
-  padding: 18px 20px;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
   border-radius: var(--ck-secondary-button-border-radius);
   border: 1px solid var(--ck-body-divider);
   background: var(--ck-secondary-button-background);
@@ -28,7 +28,7 @@ export const AmountCard = styled.div`
 `
 
 export const CurrencySymbol = styled.span`
-  font-size: 28px;
+  font-size: 18px;
   font-weight: 600;
   color: var(--ck-body-color-muted);
   line-height: 1;
@@ -39,7 +39,7 @@ export const AmountInput = styled.input`
   border: none;
   background: transparent;
   color: var(--ck-body-color);
-  font-size: 44px;
+  font-size: 24px;
   font-weight: 600;
   line-height: 1;
   padding: 0;
@@ -59,12 +59,12 @@ export const PresetList = styled.div`
 
 export const PresetButton = styled.button<{ $active?: boolean }>`
   flex: 1;
-  padding: 10px 14px;
+  padding: 8px 12px;
   border-radius: 999px;
   border: none;
   background: ${({ $active }) => ($active ? 'var(--ck-accent-color)' : 'var(--ck-secondary-button-background)')};
   color: ${({ $active }) => ($active ? 'var(--ck-accent-text-color)' : 'var(--ck-body-color)')};
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   cursor: pointer;
 
@@ -78,7 +78,7 @@ export const SelectorButton = styled.button`
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 14px 16px;
+  padding: 10px 14px;
   border-radius: var(--ck-secondary-button-border-radius);
   border: 1px solid var(--ck-body-divider);
   background: var(--ck-secondary-button-background);

--- a/packages/openfort-react/src/components/Pages/Deposit/TestnetNotice.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/TestnetNotice.tsx
@@ -1,8 +1,12 @@
 'use client'
 
+import { ChainTypeEnum } from '@openfort/openfort-js'
 import { useEffect, useState } from 'react'
+import { useEthereumEmbeddedWallet } from '../../../ethereum/hooks/useEthereumEmbeddedWallet'
+import { useOpenfortCore } from '../../../openfort/useOpenfort'
+import { useSolanaEmbeddedWallet } from '../../../solana/hooks/useSolanaEmbeddedWallet'
 import styled from '../../../styles/styled'
-import { getPublishableKeyEnvironment } from '../../../utils/validation'
+import { isTestnetChainId } from '../../../utils/rpc'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 
 /** Relay's own testnet guide — the authoritative explanation of the limitation. */
@@ -139,7 +143,10 @@ const DocsLink = styled.a`
  * Renders nothing on live keys.
  */
 export function TestnetNotice() {
-  const { publishableKey, triggerResize } = useOpenfort()
+  const { triggerResize } = useOpenfort()
+  const { chainType } = useOpenfortCore()
+  const ethereumWallet = useEthereumEmbeddedWallet()
+  const solanaWallet = useSolanaEmbeddedWallet()
   const [open, setOpen] = useState(false)
 
   // Re-measure the modal when the details expand/collapse so it grows/shrinks to fit.
@@ -147,7 +154,14 @@ export function TestnetNotice() {
     triggerResize()
   }, [open, triggerResize])
 
-  if (getPublishableKeyEnvironment(publishableKey) !== 'test') return null
+  // Testnet is a property of the active chain, not the publishable key — read it
+  // from the connected embedded wallet so the notice tracks the real deposit network.
+  const isTestnet =
+    chainType === ChainTypeEnum.SVM
+      ? solanaWallet.status === 'connected' && solanaWallet.cluster !== 'mainnet-beta'
+      : ethereumWallet.status === 'connected' && isTestnetChainId(ethereumWallet.chainId)
+
+  if (!isTestnet) return null
 
   return (
     <Card>

--- a/packages/openfort-react/src/components/Pages/Deposit/index.tsx
+++ b/packages/openfort-react/src/components/Pages/Deposit/index.tsx
@@ -27,7 +27,6 @@ import {
   OptionSubtitle,
   OptionTitle,
 } from './styles'
-import { TestnetNotice } from './TestnetNotice'
 import { UnsupportedNetworkNotice } from './UnsupportedNetworkNotice'
 import { useFundingTarget } from './useFundingTarget'
 
@@ -141,7 +140,6 @@ const Deposit = () => {
   return (
     <PageContent onBack={routes.CONNECTED}>
       <ModalHeading>Add funds</ModalHeading>
-      <TestnetNotice />
       {targetUnsupported ? (
         <UnsupportedNetworkNotice targetChain={target.chain} railChains={railChains} />
       ) : (

--- a/packages/openfort-react/src/components/Pages/Deposit/sources.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/sources.ts
@@ -16,6 +16,10 @@ export const DEST_USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
 export const DEST_CHAIN_SOL = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
 export const DEST_USDC_SOL = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
 
+/** EVM native-asset sentinel (zero address) — the default destination currency on
+ * chains where we don't ship a stablecoin address (e.g. testnets). */
+export const NATIVE_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000'
+
 /** True for a CAIP-2 Solana chain id. */
 export function isSolana(chain: string): boolean {
   return chain.startsWith('solana:')

--- a/packages/openfort-react/src/components/Pages/Deposit/useFundingTarget.ts
+++ b/packages/openfort-react/src/components/Pages/Deposit/useFundingTarget.ts
@@ -1,23 +1,38 @@
 'use client'
 
 import { ChainTypeEnum } from '@openfort/openfort-js'
+import { useEthereumEmbeddedWallet } from '../../../ethereum/hooks/useEthereumEmbeddedWallet'
 import { useOpenfortCore } from '../../../openfort/useOpenfort'
 import { useOpenfort } from '../../Openfort/useOpenfort'
-import { DEST_CHAIN, DEST_CHAIN_SOL, DEST_USDC, DEST_USDC_SOL } from './sources'
+import { DEST_CHAIN, DEST_CHAIN_SOL, DEST_USDC, DEST_USDC_SOL, NATIVE_TOKEN_ADDRESS } from './sources'
 
 /**
  * The destination route Deposit-hub funding settles into. Integrators override the
- * chain and currency via `uiConfig.funding.{targetChain,targetCurrency}`; both
- * default to USDC on the active chain type (Base for EVM, Solana mainnet for SVM)
- * so the flow works with zero configuration. The deposit recipient is always the
- * active embedded wallet for the destination chain family — callers resolve it.
+ * chain and currency via `uiConfig.funding.{targetChain,targetCurrency}`. With no
+ * override the destination follows the wallet's ACTIVE chain — so a testnet wallet
+ * funds on its own network instead of being told "funding isn't available on Base".
+ * Currency defaults to USDC where we ship its address (Base, Solana mainnet) and to
+ * the native asset otherwise, so the destination currency is always valid on-chain.
+ * The deposit recipient is always the active embedded wallet — callers resolve it.
  */
 export function useFundingTarget(): { chain: string; currency: string } {
   const { uiConfig } = useOpenfort()
   const { chainType } = useOpenfortCore()
+  const ethereumWallet = useEthereumEmbeddedWallet()
   const isSolana = chainType === ChainTypeEnum.SVM
+
+  const activeChain = isSolana
+    ? DEST_CHAIN_SOL
+    : ethereumWallet.status === 'connected'
+      ? `eip155:${ethereumWallet.chainId}`
+      : DEST_CHAIN
+  const chain = uiConfig.funding?.targetChain ?? activeChain
+
+  const defaultCurrency =
+    chain === DEST_CHAIN ? DEST_USDC : chain === DEST_CHAIN_SOL ? DEST_USDC_SOL : NATIVE_TOKEN_ADDRESS
+
   return {
-    chain: uiConfig.funding?.targetChain ?? (isSolana ? DEST_CHAIN_SOL : DEST_CHAIN),
-    currency: uiConfig.funding?.targetCurrency ?? (isSolana ? DEST_USDC_SOL : DEST_USDC),
+    chain,
+    currency: uiConfig.funding?.targetCurrency ?? defaultCurrency,
   }
 }

--- a/packages/openfort-react/src/components/Pages/DepositCex/index.tsx
+++ b/packages/openfort-react/src/components/Pages/DepositCex/index.tsx
@@ -23,6 +23,7 @@ import { DepositStatus } from '../Deposit/DepositStatus'
 import { walletListBtn } from '../Deposit/formStyles'
 import { DEST_USDC, isSolana } from '../Deposit/sources'
 import { ButtonLogo, StepDivider } from '../Deposit/styles'
+import { TestnetNotice } from '../Deposit/TestnetNotice'
 import { useFundingTarget } from '../Deposit/useFundingTarget'
 import { sanitizeAmountInput, sanitizeForParsing } from '../Send/utils'
 
@@ -222,6 +223,8 @@ const DepositCex = () => {
   return (
     <PageContent onBack={routes.DEPOSIT}>
       <ModalHeading>Transfer from Exchange</ModalHeading>
+
+      <TestnetNotice />
 
       <Section>
         <SectionLabel>Amount</SectionLabel>

--- a/packages/openfort-react/src/components/Pages/Send/EthereumSend.tsx
+++ b/packages/openfort-react/src/components/Pages/Send/EthereumSend.tsx
@@ -6,7 +6,7 @@
  * EVM asset send form (ERC-20 and native ETH).
  */
 
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { formatUnits, isAddress, parseUnits } from 'viem'
 import { useEthereumWalletAssets } from '../../../ethereum/hooks/useEthereumWalletAssets'
 import Button from '../../Common/Button'
@@ -16,8 +16,8 @@ import { ModalHeading } from '../../Common/Modal/styles'
 import { type Asset, routes, type SendFormState } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
+import { AmountCard, AmountInput } from '../Buy/styles'
 import {
-  AmountInputWrapper,
   ErrorText,
   Field,
   FieldLabel,
@@ -32,7 +32,13 @@ import {
 import { formatBalance, isSameToken, sanitizeAmountInput, sanitizeForParsing } from './utils'
 
 export const EthereumSend = () => {
-  const { sendForm, setSendForm, setRoute } = useOpenfort()
+  const { sendForm, setSendForm, setRoute, triggerResize } = useOpenfort()
+
+  // Size the modal to the form on mount. Without this the screen isn't anchored
+  // and scrolls within the modal — every other Page triggers a resize on mount.
+  useEffect(() => {
+    triggerResize()
+  }, [triggerResize])
 
   const { data: assets } = useEthereumWalletAssets()
 
@@ -139,19 +145,18 @@ export const EthereumSend = () => {
 
         <Field>
           <FieldLabel>Amount</FieldLabel>
-          <AmountInputWrapper>
-            <Input
+          <AmountCard style={{ marginTop: 12 }}>
+            <AmountInput
               placeholder="0.00"
               value={sendForm.amount}
               onChange={handleAmountChange}
               inputMode="decimal"
               autoComplete="off"
-              style={{ paddingRight: '86px' }}
             />
             <MaxButton type="button" onClick={handleMax} disabled={maxDisabled}>
               Max
             </MaxButton>
-          </AmountInputWrapper>
+          </AmountCard>
           <HelperText>
             Available: {availableLabel} {selectedSymbol}
           </HelperText>

--- a/packages/openfort-react/src/components/Pages/Send/SolanaSend.tsx
+++ b/packages/openfort-react/src/components/Pages/Send/SolanaSend.tsx
@@ -8,7 +8,7 @@
  * SolanaSendConfirmation page.
  */
 
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { formatUnits, parseUnits } from 'viem'
 import { useSolanaWalletAssets } from '../../../solana/hooks/useSolanaWalletAssets'
 import Button from '../../Common/Button'
@@ -18,8 +18,8 @@ import { ModalHeading } from '../../Common/Modal/styles'
 import { type Asset, routes, type SendFormState } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
+import { AmountCard, AmountInput } from '../Buy/styles'
 import {
-  AmountInputWrapper,
   ErrorText,
   Field,
   FieldLabel,
@@ -50,8 +50,13 @@ function solAsset(balance: bigint): Asset {
 }
 
 export const SolanaSend = () => {
-  const { sendForm, setSendForm, setRoute } = useOpenfort()
+  const { sendForm, setSendForm, setRoute, triggerResize } = useOpenfort()
   const { data: assets } = useSolanaWalletAssets()
+
+  // Size the modal to the form on mount so it's anchored and doesn't scroll.
+  useEffect(() => {
+    triggerResize()
+  }, [triggerResize])
 
   const asset = sendForm.asset
   const selected =
@@ -141,19 +146,18 @@ export const SolanaSend = () => {
 
         <Field>
           <FieldLabel>Amount</FieldLabel>
-          <AmountInputWrapper>
-            <Input
+          <AmountCard style={{ marginTop: 12 }}>
+            <AmountInput
               placeholder="0.00"
               value={sendForm.amount}
               onChange={handleAmountChange}
               inputMode="decimal"
               autoComplete="off"
-              style={{ paddingRight: '86px' }}
             />
             <MaxButton type="button" onClick={handleMax} disabled={balanceBase === undefined}>
               Max
             </MaxButton>
-          </AmountInputWrapper>
+          </AmountCard>
           <HelperText>
             Available: {availableLabel} {selected.symbol}
           </HelperText>

--- a/packages/openfort-react/src/components/Pages/Send/styles.ts
+++ b/packages/openfort-react/src/components/Pages/Send/styles.ts
@@ -70,20 +70,8 @@ export const TokenSelectorRight = styled.div`
   color: var(--ck-body-color-muted);
 `
 
-export const AmountInputWrapper = styled.div`
-  position: relative;
-  margin-top: 12px;
-
-  > div {
-    margin: 0;
-  }
-`
-
 export const MaxButton = styled.button`
-  position: absolute;
-  right: 12px;
-  top: 50%;
-  transform: translateY(-50%);
+  flex-shrink: 0;
   padding: 6px 14px;
   border-radius: 16px;
   border: 1px solid var(--ck-body-divider);

--- a/packages/openfort-react/src/components/Pages/SendConfirmation/index.tsx
+++ b/packages/openfort-react/src/components/Pages/SendConfirmation/index.tsx
@@ -21,7 +21,7 @@ import { getExplorerUrl } from '../../../shared/utils/explorer'
 import { truncateEthAddress } from '../../../utils'
 import { parseTransactionError } from '../../../utils/errorHandling'
 import { logger } from '../../../utils/logger'
-import { getChainName, getDefaultEthereumRpcUrl } from '../../../utils/rpc'
+import { getChainName, getDefaultEthereumRpcUrl, isTestnetChainId } from '../../../utils/rpc'
 import Button from '../../Common/Button'
 import Loader from '../../Common/Loading'
 import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
@@ -42,12 +42,6 @@ import {
   StatusMessage,
 } from './styles'
 
-/** Check if chain is a testnet */
-function isTestnetChain(chainId: number): boolean {
-  const testnets = new Set([5, 11155111, 80001, 84532, 421614, 97, 4002])
-  return testnets.has(chainId)
-}
-
 const SendConfirmation = () => {
   const wallet = useEthereumEmbeddedWallet()
   const { chainType } = useOpenfortCore()
@@ -66,7 +60,7 @@ const SendConfirmation = () => {
             url: getExplorerUrl(ChainTypeEnum.EVM, { chainId }),
           },
         },
-        testnet: isTestnetChain(chainId),
+        testnet: isTestnetChainId(chainId),
       }
     : undefined
 

--- a/packages/openfort-react/src/components/Pages/SendConfirmation/index.tsx
+++ b/packages/openfort-react/src/components/Pages/SendConfirmation/index.tsx
@@ -21,7 +21,7 @@ import { getExplorerUrl } from '../../../shared/utils/explorer'
 import { truncateEthAddress } from '../../../utils'
 import { parseTransactionError } from '../../../utils/errorHandling'
 import { logger } from '../../../utils/logger'
-import { getChainName, getDefaultEthereumRpcUrl, isTestnetChainId } from '../../../utils/rpc'
+import { getChainName, getDefaultEthereumRpcUrl } from '../../../utils/rpc'
 import Button from '../../Common/Button'
 import Loader from '../../Common/Loading'
 import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
@@ -50,19 +50,7 @@ const SendConfirmation = () => {
   const address = wallet.status === 'connected' ? (wallet.address as `0x${string}`) : undefined
   const chainId = wallet.status === 'connected' ? wallet.chainId : undefined
 
-  // Build chain info for block explorer
-  const chain = chainId
-    ? {
-        id: chainId,
-        name: getChainName(chainId),
-        blockExplorers: {
-          default: {
-            url: getExplorerUrl(ChainTypeEnum.EVM, { chainId }),
-          },
-        },
-        testnet: isTestnetChainId(chainId),
-      }
-    : undefined
+  const blockExplorerUrl = chainId ? getExplorerUrl(ChainTypeEnum.EVM, { chainId }) : undefined
 
   const recipientAddress = isAddress(sendForm.recipient) ? (sendForm.recipient as Address) : undefined
   const normalisedAmount = sanitizeForParsing(sendForm.amount)
@@ -352,8 +340,6 @@ const SendConfirmation = () => {
 
   const status: 'idle' | 'success' | 'error' = isSuccess ? 'success' : firstError ? 'error' : 'idle'
   const errorDetails = status === 'error' ? parseTransactionError(firstError) : null
-
-  const blockExplorerUrl = chain?.blockExplorers?.default?.url
 
   const handleOpenBlockExplorer = () => {
     if (receipt?.transactionHash && blockExplorerUrl) {

--- a/packages/openfort-react/src/localizations/locales/en-US.ts
+++ b/packages/openfort-react/src/localizations/locales/en-US.ts
@@ -101,7 +101,7 @@ const enUS = {
   injectionScreen_notconnected_p: `To continue, please login to your {{ CONNECTORNAME }} extension.`,
 
   profileScreen_heading: 'Connected',
-  buyScreen_heading: 'Add funds',
+  buyScreen_heading: 'Add funds from card',
   buyScreen_subheading: 'Select an amount and token to top up.',
   buyScreen_payWithCard_title: 'Pay with card',
   buyScreen_payWithCard_description: 'Use Stripe or Google Pay for a quick card purchase.',

--- a/packages/openfort-react/src/utils/rpc.ts
+++ b/packages/openfort-react/src/utils/rpc.ts
@@ -21,6 +21,18 @@ const KNOWN_CHAINS: Record<number, Chain> = {
   [arbitrumSepolia.id]: arbitrumSepolia,
 }
 
+/** Testnets not in {@link KNOWN_CHAINS} but still worth recognizing (deprecated/uncommon). */
+const EXTRA_TESTNET_CHAIN_IDS = new Set<number>([5, 80001, 97, 4002])
+
+/**
+ * Whether an EVM chain id is a testnet. Reads viem's chain metadata (`testnet`)
+ * for the chains the SDK bundles, falling back to a small extra set. Use this to
+ * key behaviour off the wallet's active chain rather than the publishable key.
+ */
+export function isTestnetChainId(chainId: number): boolean {
+  return KNOWN_CHAINS[chainId]?.testnet === true || EXTRA_TESTNET_CHAIN_IDS.has(chainId)
+}
+
 /**
  * Default Solana RPC URLs by cluster.
  * Production apps should provide their own RPCs via walletConfig.solana.rpcUrls.


### PR DESCRIPTION
Follow-up UI/logic tweaks on top of the send-confirmation work (#298).

## Changes

- **Anchor the send form.** `EthereumSend` and `SolanaSend` now trigger a modal resize on mount, so the prepare-transaction screen sizes to its content instead of scrolling within the modal (every other Page already did this).
- **Compact amount UI.** Shrinks the Buy ("Add funds from card") amount input (44px → 24px), presets, currency selector and card padding. The send form reuses the same `AmountCard`/`AmountInput`, so amount entry looks consistent across buy and send.
- **Rename.** Buy heading `Add funds` → `Add funds from card`.
- **Active-chain testnet check.** `TestnetNotice` now derives testnet state from the wallet's active chain (`isTestnetChainId` for EVM, Solana cluster) instead of the publishable-key environment, and renders only on the relay deposit page (`DepositCrypto`) — removed from the Add funds hub.
- Promotes `isTestnetChainId` into `utils/rpc` (sourced from viem chain metadata) and reuses it in `SendConfirmation`.

Verified locally: `tsc`, `biome`, `knip`, and `pnpm build` all pass. Send form, Buy screen, and the testnet-notice placement checked in the docs interactive demo.