### PR TITLE
chore(design-sync): Claude Design sync inputs for @openfort/react

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,52 @@
+# design-sync notes — @openfort/react
+
+Repo-specific gotchas for syncing `@openfort/react` to claude.ai/design (project: Openfort React UI).
+
+## ⚠️ Untracked files get cleaned — keep `.design-sync/` git-tracked
+An active process in this environment removes untracked, non-gitignored files (it wiped a scratch `ds-bundle-test/` and the whole `.design-sync/` durable set mid-run once). **Always `git add` the durable `.design-sync/` files** (config, NOTES, conventions, previews, stubs, preview-tsconfig, pages-entry) so they survive. Gitignored dirs (`.design-sync/.cache/`, `ds-bundle/`) and the staged scripts are fine.
+
+## Build / entry
+- Package manager: **pnpm** (`only-allow pnpm`); install with `pnpm i --frozen-lockfile`. Use `COREPACK_ENABLE_STRICT=0` to use the system pnpm.
+- Converter dep install (`npm i esbuild ts-morph @types/react playwright@1.58.0` in `.ds-sync/`) **must pass `--no-workspaces`**: the repo's root `package.json` `workspaces` globs include the create-openfort templates, which duplicate the example workspace names. npm walks up, reads that config, and dies with "must not have multiple workspaces with the same name". `--no-workspaces` makes npm treat `.ds-sync/` as standalone. (pnpm is unaffected.)
+- Build: `pnpm --filter @openfort/react build` (rollup, ~1.5 min, `preserveModules`). Output goes to `packages/openfort-react/build/` (NOT `dist/`).
+- Converter entry: `packages/openfort-react/build/index.js`. `--node-modules`: `packages/openfort-react/node_modules` (pnpm keeps `react`/`react-dom`/`@types/react` symlinked there; nothing hoisted to repo root).
+
+## Components & screens
+- Public visual surface: **OpenfortButton, Avatar, ChainIcon** + the **OpenfortProvider** wrapper. Everything else exported from `index.ts` is hooks/types/enums — prune PascalCase non-components via `componentSrcMap: {Name: null}` (e.g. `OpenfortError`).
+- The rich modal UI (auth/funding/wallet "Pages") is **internal** (not exported). It is surfaced for the DS via `.design-sync/pages-entry.mjs` (re-exports the built Page defaults onto `window.OpenfortReact`) + `cfg.extraEntries` + `cfg.componentSrcMap` pins. These render their real UI even disconnected because they're forms/selectors.
+- Screens included (render well disconnected): ProvidersScreen, SocialProvidersScreen, EmailLoginScreen, EmailOtpScreen, PhoneOtpScreen, ForgotPasswordScreen, OnboardingScreen, SendScreen, ReceiveScreen, SelectTokenScreen, DepositScreen, BuyScreen, BuySelectProviderScreen, DepositCexScreen, DepositCryptoScreen, DepositWalletScreen, ProfileScreen, AboutScreen, ExportKeyScreen.
+- Screens EXCLUDED (need a live wallet/wagmi — render as floor card or error bar): **Connected** (ConnectKitThemeProvider error), **CreateWallet**/**Connectors** ("No connection found in Openfort config" red bar — need wagmi connectors), **Recover** (floor), **LinkedProviders**/**SelectWalletToRecover** (sparse/empty). DepositCrypto/DepositWallet render light ("funding isn't available right now") but show the real header — kept.
+
+## Provider
+- All components require `OpenfortProvider` context. `cfg.provider` = `OpenfortProvider` with a fake `publishableKey: "pk_test_preview"`.
+- wagmi + react-query are NOT required for static (disconnected) render. The full `QueryClient → Wagmi → OpenfortWagmiBridge → OpenfortProvider` chain (see examples/quickstarts/openfort-ui/src/components/providers.tsx) is only for connected/live states. The bundle is built from the MAIN entry only — `window.OpenfortReact` does NOT expose the `/wagmi` bridge.
+
+## Styling idiom
+- CSS-in-JS via **styled-components** + framer-motion. Styles inject at runtime → expect `[CSS_RUNTIME]` (self-styling bundle, no static stylesheet). Non-blocking.
+- Theme tokens are CSS custom properties `--ck-*` (src/styles/customTheme.ts). Named theme presets via the `theme` prop: `auto | web95 | retro | soft | midnight | minimal | rounded | nouns`; `mode`: `light | dark | auto`.
+
+## Bundle slimming (REQUIRED — keeps bundle under the 5 MB upload cap)
+- The full bundle is ~5.4 MB unminified (`[FILE_OVER_5MB]`). The single biggest non-render dependency is **Sentry telemetry** (~1.15 MB), pulled in only by `@openfort/openfort-js`.
+- Stubbed via the converter's supported `cfg.tsconfig` path-alias plugin (NO fork of lib/bundle.mjs):
+  - `cfg.tsconfig` = `../../.design-sync/preview-tsconfig.json` (package-relative; resolves to the repo-root file, inside the git workspaceRoot bound).
+  - Maps `@sentry/browser` → `.design-sync/stubs/sentry-browser.js` (the only top-level Sentry specifier; transitive @sentry/* then never resolve).
+  - **The tsconfig must NOT contain a `"//"` doc key** — the converter's tsconfig-paths plugin strips `//` comments naively; a `"//"` key corrupts the JSON and silently disables the plugin (bundle balloons back to 5.4 MB).
+  - The stub exports real named `BrowserClient` / `defaultStackParser` / `makeFetchTransport` (the SDK does `await import('@sentry/browser')` then `new a.BrowserClient(...)`). A bare Proxy fails — esbuild's CJS→ESM interop snapshots own keys. `BrowserClient.getDsn()` returns parts matching the SDK's hardcoded DSN so `init()` completes silently.
+- Result: bundle ~4.6 MB even with the screens added (they were already inside the bundle).
+
+## Render check (playwright)
+- Cached chromium builds: 1148, 1208. **`playwright@1.58.0` pins chromium 1208** → install that in `.ds-sync` to reuse the cache with no ~150 MB download. (Repo pins playwright 1.61.0 → chromium 1228, NOT cached.)
+
+## Known render warns (triaged)
+- `[CSS_RUNTIME]` styles.css has no @imports — expected: styled-components injects at runtime.
+- OpenfortProvider shows the **floor card** by design (it's the wrapper; rendering it inside cfg.provider trips "Multiple, nested usages"). Do NOT "fix" it.
+
+## Composition sources (for authored previews)
+- ChainIcon ids with logos: Ethereum 1, Optimism 10, Polygon 137, Arbitrum One 42161, Base 8453, Zora 7777777. Avatar gradient (`--ck-ens-0X-*`, 8 color pairs) is seeded from the address; pass `unsupported={false}` to ChainIcon to suppress the warning overlay.
+- Screen previews are zero-prop: `export const Default = () => <XScreen />`.
+
+## Re-sync risks (what can silently go stale)
+- **Sentry DSN hardcode (`stubs/sentry-browser.js`)**: `getDsn()` must match the DSN hardcoded in `@openfort/openfort-js`'s `core/errors/sentry.js`. If the SDK bumps its DSN, `init()` throws async noise that re-flags components `bad`. Fix: copy the new DSN parts in. Verify after any openfort-js bump.
+- **Single Sentry specifier assumption**: slimming relies on `@sentry/browser` being the ONLY top-level `@sentry/*` import. If `[FILE_OVER_5MB]` returns, re-trace importers (esbuild metafile) and add new specifiers to `preview-tsconfig.json` + a stub.
+- **Screen rendering depends on disconnected states staying renderable**: if upstream makes a screen hard-require a live wallet, it may drop to a floor card / error bar. Re-check the contact sheet and move it to the excluded list if so.
+- **playwright/chromium cache**: re-find a playwright version matching a cached chromium build on a fresh machine, or accept a download. `.ds-sync/node_modules` is gitignored — reinstall converter deps per clone.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,40 @@
+{
+  "pkg": "@openfort/react",
+  "globalName": "OpenfortReact",
+  "projectId": "e7f20843-3a6a-4892-b91b-802d05504e5e",
+  "shape": "package",
+  "buildCmd": "pnpm --filter @openfort/react build",
+  "readmeHeader": ".design-sync/conventions.md",
+  "entry": "./packages/openfort-react/build/index.js",
+  "tsconfig": "../../.design-sync/preview-tsconfig.json",
+  "extraEntries": [
+    "../../.design-sync/pages-entry.mjs"
+  ],
+  "componentSrcMap": {
+    "OpenfortError": null,
+    "ProvidersScreen": "src/components/Pages/Providers/index.tsx",
+    "EmailLoginScreen": "src/components/Pages/EmailLogin/index.tsx",
+    "EmailOtpScreen": "src/components/Pages/EmailOTP/index.tsx",
+    "PhoneOtpScreen": "src/components/Pages/PhoneOTP/index.tsx",
+    "ForgotPasswordScreen": "src/components/Pages/ForgotPassword/index.tsx",
+    "OnboardingScreen": "src/components/Pages/Onboarding/index.tsx",
+    "SendScreen": "src/components/Pages/Send/index.tsx",
+    "ReceiveScreen": "src/components/Pages/Receive/index.tsx",
+    "SelectTokenScreen": "src/components/Pages/SelectToken/index.tsx",
+    "DepositScreen": "src/components/Pages/Deposit/index.tsx",
+    "BuyScreen": "src/components/Pages/Buy/index.tsx",
+    "BuySelectProviderScreen": "src/components/Pages/BuySelectProvider/index.tsx",
+    "DepositCexScreen": "src/components/Pages/DepositCex/index.tsx",
+    "DepositCryptoScreen": "src/components/Pages/DepositCrypto/index.tsx",
+    "DepositWalletScreen": "src/components/Pages/DepositWallet/index.tsx",
+    "ProfileScreen": "src/components/Pages/Profile/index.tsx",
+    "AboutScreen": "src/components/Pages/About/index.tsx",
+    "ExportKeyScreen": "src/components/Pages/ExportKey/index.tsx"
+  },
+  "provider": {
+    "component": "OpenfortProvider",
+    "props": {
+      "publishableKey": "pk_test_preview"
+    }
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,67 @@
+## Building with @openfort/react
+
+`@openfort/react` is a wallet-integration UI library. The composable components are
+**`OpenfortButton`** (the connect button that opens the auth/wallet modal),
+**`Avatar`** (a wallet identicon), and **`ChainIcon`** (a network logo), all powered
+by **`OpenfortProvider`**, the required root wrapper. The design system also includes
+the modal **screens** that live behind `OpenfortButton` (e.g. `ProvidersScreen` =
+the connect screen, `SendScreen`, `ReceiveScreen`, `DepositScreen`, `BuyScreen`,
+`ProfileScreen`) for reference — see "Screens" below.
+
+### Wrapping and setup (required)
+
+Every component reads theme, locale, and wallet state from `OpenfortProvider`'s context.
+Rendering any of them outside the provider throws or renders blank. Wrap the subtree once:
+
+```jsx
+const { OpenfortProvider, OpenfortButton } = window.OpenfortReact
+
+function App() {
+  return (
+    <OpenfortProvider publishableKey="pk_test_xxx">
+      <main style={{ display: 'grid', placeItems: 'center', minHeight: '100dvh' }}>
+        <OpenfortButton label="Sign in" />
+      </main>
+    </OpenfortProvider>
+  )
+}
+```
+
+- `publishableKey` is required (any non-empty string renders; a real Openfort key is needed
+  for live auth). Mount `OpenfortProvider` **once** — nesting it throws "Multiple, nested
+  usages of OpenfortProvider".
+- In a production app, external-wallet (EVM) sign-in additionally needs the wagmi chain
+  (`QueryClientProvider → WagmiProvider → OpenfortWagmiBridge → OpenfortProvider`, from
+  `@openfort/react/wagmi`). That wiring lives in the host app, not this bundle — see the
+  full snippet and links in `README.md`. It is not needed to render or compose these
+  components in a design.
+
+### Styling idiom — props, not classes
+
+There is **no utility-class system**. Components style themselves at runtime (styled-components),
+so you restyle them through props, and lay out *around* them with your own CSS / inline styles:
+
+- **`theme`** — one of `"auto" | "web95" | "retro" | "soft" | "midnight" | "minimal" | "rounded" | "nouns"`.
+  Switches the whole look (border radius, color, weight). Set on `OpenfortButton` directly, or
+  app-wide via `OpenfortProvider`'s `uiConfig={{ theme }}`.
+- **`mode`** — `"light" | "dark" | "auto"`.
+- **`customTheme`** — fine-grained overrides as CSS custom properties named `--ck-*`
+  (e.g. `--ck-connectbutton-background`, `--ck-border-radius`, `--ck-font-family`). See the
+  `CustomTheme` type in `OpenfortButton.d.ts`.
+
+`Avatar` (`address`, `size`, `radius`) draws a deterministic gradient identicon seeded from the
+address. `ChainIcon` (`id`, `size`, `unsupported`) renders a network logo by EVM chain id.
+
+### Screens (the modal flows)
+
+`*Screen` components are the internal pages of the connect modal, surfaced here for reference.
+They are **not part of the public `@openfort/react` API** — in a real app they appear inside the
+`OpenfortButton` modal, routed automatically; you do not place them yourself. Use them to see and
+match the look of the connect, send, receive, and funding flows. Each is zero-prop and renders
+inside `OpenfortProvider`.
+
+### Where the truth lives
+
+Per component, read `components/<group>/<Name>/<Name>.prompt.md` (usage + variants) and
+`<Name>.d.ts` (the prop contract) before composing. The bundle is self-styling — there is no
+component stylesheet to import beyond `styles.css`.

--- a/.design-sync/pages-entry.mjs
+++ b/.design-sync/pages-entry.mjs
@@ -1,0 +1,32 @@
+// Surfaces the internal modal "Pages" (Send, Receive, funding, etc.) on
+// window.OpenfortReact for the design-sync bundle. These are NOT part of
+// @openfort/react's public API; they normally render inside the connect modal,
+// routed by OpenfortProvider. Re-exported here from the built dist so the
+// design system can show the screens that live behind OpenfortButton.
+// Wired via cfg.extraEntries; each name is also pinned in cfg.componentSrcMap.
+
+// ── Connect / auth ──────────────────────────────────────────────────────────
+export { default as ProvidersScreen } from '../packages/openfort-react/build/components/Pages/Providers/index.js'
+export { default as EmailLoginScreen } from '../packages/openfort-react/build/components/Pages/EmailLogin/index.js'
+export { default as EmailOtpScreen } from '../packages/openfort-react/build/components/Pages/EmailOTP/index.js'
+export { default as PhoneOtpScreen } from '../packages/openfort-react/build/components/Pages/PhoneOTP/index.js'
+export { default as ForgotPasswordScreen } from '../packages/openfort-react/build/components/Pages/ForgotPassword/index.js'
+export { default as OnboardingScreen } from '../packages/openfort-react/build/components/Pages/Onboarding/index.js'
+
+// ── Wallet actions ──────────────────────────────────────────────────────────
+export { default as SendScreen } from '../packages/openfort-react/build/components/Pages/Send/index.js'
+export { default as ReceiveScreen } from '../packages/openfort-react/build/components/Pages/Receive/index.js'
+export { default as SelectTokenScreen } from '../packages/openfort-react/build/components/Pages/SelectToken/index.js'
+
+// ── Funding ─────────────────────────────────────────────────────────────────
+export { default as DepositScreen } from '../packages/openfort-react/build/components/Pages/Deposit/index.js'
+export { default as BuyScreen } from '../packages/openfort-react/build/components/Pages/Buy/index.js'
+export { default as BuySelectProviderScreen } from '../packages/openfort-react/build/components/Pages/BuySelectProvider/index.js'
+export { default as DepositCexScreen } from '../packages/openfort-react/build/components/Pages/DepositCex/index.js'
+export { default as DepositCryptoScreen } from '../packages/openfort-react/build/components/Pages/DepositCrypto/index.js'
+export { default as DepositWalletScreen } from '../packages/openfort-react/build/components/Pages/DepositWallet/index.js'
+
+// ── Account / security ──────────────────────────────────────────────────────
+export { default as ProfileScreen } from '../packages/openfort-react/build/components/Pages/Profile/index.js'
+export { default as AboutScreen } from '../packages/openfort-react/build/components/Pages/About/index.js'
+export { default as ExportKeyScreen } from '../packages/openfort-react/build/components/Pages/ExportKey/index.js'

--- a/.design-sync/preview-tsconfig.json
+++ b/.design-sync/preview-tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@sentry/browser": ["./stubs/sentry-browser.js"]
+    }
+  }
+}

--- a/.design-sync/previews/AboutScreen.tsx
+++ b/.design-sync/previews/AboutScreen.tsx
@@ -1,0 +1,5 @@
+import { AboutScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <AboutScreen />

--- a/.design-sync/previews/Avatar.tsx
+++ b/.design-sync/previews/Avatar.tsx
@@ -1,0 +1,35 @@
+import { Avatar } from '@openfort/react'
+
+// Wallet avatar: a deterministic gradient identicon derived from the address
+// (falls back to an ENS image when one resolves on Ethereum mainnet). The
+// gradient palette is seeded from the address, so different wallets get
+// different colors.
+
+const VITALIK = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
+
+export const Default = () => <Avatar address={VITALIK} size={64} radius={64} />
+
+export const Sizes = () => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+    <Avatar address={VITALIK} size={24} radius={24} />
+    <Avatar address={VITALIK} size={40} radius={40} />
+    <Avatar address={VITALIK} size={56} radius={56} />
+    <Avatar address={VITALIK} size={72} radius={72} />
+  </div>
+)
+
+export const Gallery = () => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+    {[
+      '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+      '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
+      '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+      '0x2170Ed0880ac9A755fd29B2688956BD959F933F8',
+      '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+    ].map((address) => (
+      <Avatar key={address} address={address} size={48} radius={48} />
+    ))}
+  </div>
+)
+
+export const Squircle = () => <Avatar address={VITALIK} size={64} radius={16} />

--- a/.design-sync/previews/BuyScreen.tsx
+++ b/.design-sync/previews/BuyScreen.tsx
@@ -1,0 +1,5 @@
+import { BuyScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <BuyScreen />

--- a/.design-sync/previews/BuySelectProviderScreen.tsx
+++ b/.design-sync/previews/BuySelectProviderScreen.tsx
@@ -1,0 +1,5 @@
+import { BuySelectProviderScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <BuySelectProviderScreen />

--- a/.design-sync/previews/ChainIcon.tsx
+++ b/.design-sync/previews/ChainIcon.tsx
@@ -1,0 +1,25 @@
+import { ChainIcon } from '@openfort/react'
+
+// Chain icon: renders a network's logo by its EVM chain id. Shows a loading
+// spinner when no id is given and an "unsupported network" warning badge when
+// the chain isn't in the configured set.
+
+export const Default = () => <ChainIcon id={1} unsupported={false} size={48} />
+
+export const Gallery = () => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+    {[1, 10, 137, 42161, 8453, 7777777].map((id) => (
+      <ChainIcon key={id} id={id} unsupported={false} size={40} />
+    ))}
+  </div>
+)
+
+export const Sizes = () => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+    <ChainIcon id={1} unsupported={false} size={24} />
+    <ChainIcon id={1} unsupported={false} size={36} />
+    <ChainIcon id={1} unsupported={false} size={48} />
+  </div>
+)
+
+export const Unsupported = () => <ChainIcon id={1} unsupported size={48} />

--- a/.design-sync/previews/DepositCexScreen.tsx
+++ b/.design-sync/previews/DepositCexScreen.tsx
@@ -1,0 +1,5 @@
+import { DepositCexScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <DepositCexScreen />

--- a/.design-sync/previews/DepositCryptoScreen.tsx
+++ b/.design-sync/previews/DepositCryptoScreen.tsx
@@ -1,0 +1,5 @@
+import { DepositCryptoScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <DepositCryptoScreen />

--- a/.design-sync/previews/DepositScreen.tsx
+++ b/.design-sync/previews/DepositScreen.tsx
@@ -1,0 +1,5 @@
+import { DepositScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <DepositScreen />

--- a/.design-sync/previews/DepositWalletScreen.tsx
+++ b/.design-sync/previews/DepositWalletScreen.tsx
@@ -1,0 +1,5 @@
+import { DepositWalletScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <DepositWalletScreen />

--- a/.design-sync/previews/EmailLoginScreen.tsx
+++ b/.design-sync/previews/EmailLoginScreen.tsx
@@ -1,0 +1,5 @@
+import { EmailLoginScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <EmailLoginScreen />

--- a/.design-sync/previews/EmailOtpScreen.tsx
+++ b/.design-sync/previews/EmailOtpScreen.tsx
@@ -1,0 +1,5 @@
+import { EmailOtpScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <EmailOtpScreen />

--- a/.design-sync/previews/ExportKeyScreen.tsx
+++ b/.design-sync/previews/ExportKeyScreen.tsx
@@ -1,0 +1,5 @@
+import { ExportKeyScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <ExportKeyScreen />

--- a/.design-sync/previews/ForgotPasswordScreen.tsx
+++ b/.design-sync/previews/ForgotPasswordScreen.tsx
@@ -1,0 +1,5 @@
+import { ForgotPasswordScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <ForgotPasswordScreen />

--- a/.design-sync/previews/OnboardingScreen.tsx
+++ b/.design-sync/previews/OnboardingScreen.tsx
@@ -1,0 +1,5 @@
+import { OnboardingScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <OnboardingScreen />

--- a/.design-sync/previews/OpenfortButton.tsx
+++ b/.design-sync/previews/OpenfortButton.tsx
@@ -1,0 +1,17 @@
+import { OpenfortButton } from '@openfort/react'
+
+// The primary entry point: a connect button that opens the Openfort auth/wallet
+// modal. Shown here in its disconnected state. The `theme` prop restyles it with
+// one of the built-in presets.
+
+export const Default = () => <OpenfortButton />
+
+export const CustomLabel = () => <OpenfortButton label="Sign in" />
+
+export const Rounded = () => <OpenfortButton theme="rounded" label="Connect wallet" />
+
+export const Retro = () => <OpenfortButton theme="retro" label="Connect wallet" />
+
+export const Soft = () => <OpenfortButton theme="soft" label="Connect wallet" />
+
+export const Midnight = () => <OpenfortButton theme="midnight" mode="dark" label="Connect wallet" />

--- a/.design-sync/previews/PhoneOtpScreen.tsx
+++ b/.design-sync/previews/PhoneOtpScreen.tsx
@@ -1,0 +1,5 @@
+import { PhoneOtpScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <PhoneOtpScreen />

--- a/.design-sync/previews/ProfileScreen.tsx
+++ b/.design-sync/previews/ProfileScreen.tsx
@@ -1,0 +1,5 @@
+import { ProfileScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <ProfileScreen />

--- a/.design-sync/previews/ProvidersScreen.tsx
+++ b/.design-sync/previews/ProvidersScreen.tsx
@@ -1,0 +1,5 @@
+import { ProvidersScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <ProvidersScreen />

--- a/.design-sync/previews/ReceiveScreen.tsx
+++ b/.design-sync/previews/ReceiveScreen.tsx
@@ -1,0 +1,5 @@
+import { ReceiveScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <ReceiveScreen />

--- a/.design-sync/previews/SelectTokenScreen.tsx
+++ b/.design-sync/previews/SelectTokenScreen.tsx
@@ -1,0 +1,5 @@
+import { SelectTokenScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <SelectTokenScreen />

--- a/.design-sync/previews/SendScreen.tsx
+++ b/.design-sync/previews/SendScreen.tsx
@@ -1,0 +1,5 @@
+import { SendScreen } from '@openfort/react'
+
+// Internal connect-modal screen, surfaced for reference (not part of the public API).
+// Zero-prop; renders inside OpenfortProvider in its disconnected state.
+export const Default = () => <SendScreen />

--- a/.design-sync/stubs/sentry-browser.js
+++ b/.design-sync/stubs/sentry-browser.js
@@ -1,0 +1,54 @@
+// No-op stub for @sentry/browser, swapped in only for the design-sync preview
+// bundle via .design-sync/preview-tsconfig.json (cfg.tsconfig). @openfort/openfort-js
+// imports @sentry/browser purely for error telemetry; it is never needed to RENDER
+// a component, and shipping it pushes the bundle over claude.ai/design's 5 MB cap.
+//
+// @openfort/openfort-js does `const a = await import('@sentry/browser')` then
+//   new a.BrowserClient({ dsn, stackParser: a.defaultStackParser, transport: a.makeFetchTransport })
+// and validates `client.getDsn()` against its own hardcoded DSN. We therefore
+// expose those exact named exports as no-ops, and return a getDsn() whose parts
+// match the SDK's DSN so init() completes silently instead of throwing.
+// (Re-sync risk: if the SDK changes its DSN, init throws harmless async noise —
+// update DSN below. It never blocks render.)
+const DSN = {
+  projectId: '4509292415287296',
+  host: 'o4504593015242752.ingest.us.sentry.io',
+  publicKey: '64a03e4967fb4dad3ecb914918c777b6',
+}
+
+export class BrowserClient {
+  getDsn() {
+    return DSN
+  }
+  captureException() {}
+  captureMessage() {}
+  captureEvent() {}
+  getOptions() {
+    return {}
+  }
+  flush() {
+    return Promise.resolve(true)
+  }
+  close() {
+    return Promise.resolve(true)
+  }
+}
+
+export const defaultStackParser = () => []
+export function makeFetchTransport() {
+  return { send: () => Promise.resolve({}), flush: () => Promise.resolve(true) }
+}
+
+// Generic no-ops in case other Sentry surface is touched.
+export const init = () => {}
+export const captureException = () => {}
+export const getCurrentScope = () => ({ setTag() {}, setUser() {}, setExtra() {} })
+
+export default {
+  BrowserClient,
+  defaultStackParser,
+  makeFetchTransport,
+  init,
+  captureException,
+  getCurrentScope,
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,11 @@ examples/playground/tests/.auth/
 docs/
 semgrep-results-001/
 .gstack/
+
+# design-sync (claude.ai/design) — staged scripts, build output, machine state
+.ds-sync/
+ds-bundle/
+ds-bundle-test/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules


### PR DESCRIPTION
Adds reproducible inputs that sync `@openfort/react` to claude.ai/design (project **Openfort React UI**), produced by the `/design-sync` skill.

22 components synced from the real compiled package: `OpenfortButton`, `Avatar`, `ChainIcon`, `OpenfortProvider` (floor card), and 18 modal screens (Providers/Send/Receive/Deposit/Buy/Profile/etc.). Render check clean; bundle 4.6 MB.

Sync inputs only — no application code changes. `config.json` pins `@sentry/browser` to a no-op stub (`cfg.tsconfig`) to keep the bundle under the 5 MB cap, and surfaces the internal modal screens via `extraEntries` + `componentSrcMap`. See `.design-sync/NOTES.md` for re-sync gotchas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)