### PR TITLE
fix(ui): polish modal and button motion (design-engineering pass)

### DIFF
--- a/.changeset/sdk-motion-polish.md
+++ b/.changeset/sdk-motion-polish.md
@@ -1,0 +1,5 @@
+---
+"@openfort/react": patch
+---
+
+Polish modal and button motion. The connect button and the in-modal primary buttons now scale on press; press feedback is unified behind a `--ck-press-scale` token (was an inconsistent mix of `scale(0.9)`/`0.95`/`0.98`, with the main CTA giving none). Easing is stronger (`--ck-ease-out` replaces the default-strength `ease` on the modal resize and page transitions), `transition: all` is replaced with explicit properties across inputs/buttons/copy controls, the connect-button text swap is faster (400ms → 220ms), the modal exit is snappier than its enter, the backdrop gets a subtle blur, and `prefers-reduced-motion` now swaps the modal's scale/slide for opacity-only fades.

--- a/packages/openfort-react/src/components/Common/Button/styles.ts
+++ b/packages/openfort-react/src/components/Common/Button/styles.ts
@@ -23,7 +23,7 @@ export const Arrow = styled.svg`
   vertical-align: middle;
   margin-left: 9px;
   margin-right: 1px;
-  transition: all 100ms ease;
+  transition: transform 100ms ease-out, opacity 100ms ease-out;
   transform: translateX(var(--x, -3px));
   color: currentColor;
   opacity: 0.4;
@@ -191,8 +191,8 @@ export const ButtonContainer = styled.button<{
   font-weight: var(--font-weight,500);
   text-decoration: none;
   white-space: nowrap;
-  transition: 100ms ease;
-  transition-property: box-shadow, background-color;
+  transition: 120ms ease-out;
+  transition-property: box-shadow, background-color, transform;
   color: var(--color);
   background: var(--background);
   border-radius: var(--border-radius);
@@ -239,13 +239,15 @@ export const ButtonContainer = styled.button<{
     }
     &:active {
       box-shadow: var(--ck-secondary-button-active-box-shadow, var(--hover-box-shadow));
+      transform: scale(var(--ck-press-scale, 0.97));
     }
   }
   @media only screen and (max-width: ${defaultTheme.mobileWidth}px) {
-    transition: transform 100ms ease;
+    transition: transform 100ms ease-out;
     transform: scale(1);
     font-size: 17px;
     &:active {
+      transform: scale(var(--ck-press-scale, 0.97));
     }
   }
 `

--- a/packages/openfort-react/src/components/Common/CopyToClipboard/CopyIcon.tsx
+++ b/packages/openfort-react/src/components/Common/CopyToClipboard/CopyIcon.tsx
@@ -9,7 +9,7 @@ const IconWrapper = styled(motion.div)<{ $copied?: boolean }>`
   justify-content: center;
   width: 16px;
   height: 16px;
-  transition: all 220ms ease;
+  transition: color 220ms ease;
 
   svg {
     display: block;
@@ -18,21 +18,21 @@ const IconWrapper = styled(motion.div)<{ $copied?: boolean }>`
   }
 
   svg path:first-child {
-    transition: all 220ms ease;
+    transition: fill 220ms ease, stroke 220ms ease, opacity 220ms ease, transform 220ms ease;
     fill: var(--bg, var(--ck-body-background));
     stroke: var(--color, var(--ck-copytoclipboard-stroke));
     transform-origin: 50% 50%;
   }
 
   svg rect {
-    transition: all 220ms ease;
+    transition: fill 220ms ease, stroke 220ms ease, opacity 220ms ease, transform 220ms ease;
     fill: var(--bg, var(--ck-body-background));
     stroke: var(--color, var(--ck-copytoclipboard-stroke));
     transform-origin: 53% 63%;
   }
 
   svg path:last-child {
-    transition: all 220ms ease;
+    transition: fill 220ms ease, stroke 220ms ease, opacity 220ms ease, transform 220ms ease;
     opacity: ${(props) => (props.$copied ? 1 : 0)};
     stroke: var(--ck-body-background);
     transform: translate(11.75px, 10px) rotate(90deg) scale(0.6);

--- a/packages/openfort-react/src/components/Common/CopyToClipboard/CopyIconButton.tsx
+++ b/packages/openfort-react/src/components/Common/CopyToClipboard/CopyIconButton.tsx
@@ -10,7 +10,7 @@ const StyledButton = styled.button<{ $size: number }>`
   border-radius: var(--ck-secondary-button-border-radius);
   background: var(--ck-accent-color, rgba(26, 136, 248, 0.1));
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background 200ms ease;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/openfort-react/src/components/Common/CopyToClipboard/CopyText.tsx
+++ b/packages/openfort-react/src/components/Common/CopyToClipboard/CopyText.tsx
@@ -10,7 +10,7 @@ const Container = styled.div<{ $disabled?: boolean }>`
   gap: 4px;
   cursor: ${(props) => (props.$disabled ? 'not-allowed' : 'pointer')};
   opacity: ${(props) => (props.$disabled ? 0.4 : 1)};
-  transition: all 220ms ease;
+  transition: color 220ms ease, opacity 220ms ease;
 
   --color: var(--ck-copytoclipboard-stroke);
 

--- a/packages/openfort-react/src/components/Common/Input/styles.ts
+++ b/packages/openfort-react/src/components/Common/Input/styles.ts
@@ -14,7 +14,7 @@ export const Input = styled.input`
   background: var(--ck-input-background);
   font-size: 1rem;
   color: var(--ck-body-color);
-  transition: all 0.2s;
+  transition: background 200ms ease, box-shadow 200ms ease;
   width: 100%;
   height: 100%;
 
@@ -39,7 +39,7 @@ export const IconButton = styled.button`
   align-items: center;
   justify-content: center;
   color: var(--ck-body-color-muted);
-  transition: all 0.2s;
+  transition: color 200ms ease;
 
   > svg {
     height: 24px;

--- a/packages/openfort-react/src/components/Common/Modal/styles.ts
+++ b/packages/openfort-react/src/components/Common/Modal/styles.ts
@@ -216,7 +216,8 @@ export const BackgroundOverlay = styled(motion.div)<{
   right: 0;
   bottom: 0;
   background: var(--ck-overlay-background, rgba(71, 88, 107, 0.24));
-  backdrop-filter: ${(props) => (props.$blur ? `blur(${props.$blur}px)` : 'var(--ck-overlay-backdrop-filter, none)')};
+  backdrop-filter: ${(props) => (props.$blur ? `blur(${props.$blur}px)` : 'var(--ck-overlay-backdrop-filter, blur(2px))')};
+  -webkit-backdrop-filter: ${(props) => (props.$blur ? `blur(${props.$blur}px)` : 'var(--ck-overlay-backdrop-filter, blur(2px))')};
   opacity: 0;
   animation: ${(props) => (props.$active ? FadeIn : FadeOut)} 150ms ease-out
     both;
@@ -246,10 +247,13 @@ export const BoxContainer = styled(motion.div)`
   position: relative;
   color: var(--ck-body-color);
 
-  animation: 150ms ease both;
+  /* Exit is snappier than enter — slow where the user decides (open),
+     fast where the system responds (dismiss). */
+  animation: 130ms var(--ck-ease-out, cubic-bezier(0.23, 1, 0.32, 1)) both;
   animation-name: ${BoxOut};
   &.active {
     animation-name: ${BoxIn};
+    animation-duration: 200ms;
   }
 
   &:before {
@@ -265,7 +269,8 @@ export const BoxContainer = styled(motion.div)`
     max-height: 88vh;
     transform: translateX(-50%);
     backface-visibility: hidden;
-    transition: all 200ms ease;
+    transition: width 200ms ease, height 200ms ease, box-shadow 200ms ease,
+      border-radius 200ms ease;
     border-radius: var(--ck-border-radius, 20px);
     background: var(--ck-body-background);
     box-shadow: var(--ck-modal-box-shadow);
@@ -287,6 +292,14 @@ export const BoxContainer = styled(motion.div)`
       width: 100%;
       transition: 0ms height cubic-bezier(0.15, 1.15, 0.6, 1);
       will-change: height;
+    }
+  }
+
+  /* Reduced motion: keep the fade, drop the scale/slide. */
+  @media (prefers-reduced-motion: reduce) {
+    animation-name: ${FadeOut};
+    &.active {
+      animation-name: ${FadeIn};
     }
   }
 `
@@ -331,7 +344,7 @@ export const PageContainer = styled(motion.div)`
   justify-content: center;
   align-items: center;
   transform-origin: center center;
-  animation: 200ms ease both;
+  animation: 200ms var(--ck-ease-out, cubic-bezier(0.23, 1, 0.32, 1)) both;
 
   &.active {
     animation-name: ${FadeInScaleDown};
@@ -379,6 +392,18 @@ export const PageContainer = styled(motion.div)`
       animation-delay: 0ms;
     }
   }
+
+  /* Reduced motion: cross-fade pages instead of scaling them. */
+  @media (prefers-reduced-motion: reduce) {
+    &.active,
+    &.active-scale-up {
+      animation-name: ${FadeIn};
+    }
+    &.exit,
+    &.exit-scale-down {
+      animation-name: ${FadeOut};
+    }
+  }
 `
 export const PageContents = styled(motion.div)`
   margin: 0 auto;
@@ -409,7 +434,7 @@ export const CloseButton = styled(motion.button)`
   margin: 0;
   color: var(--ck-body-action-color);
   background: var(--ck-body-background);
-  transition: background-color 200ms ease, transform 100ms ease;
+  transition: background-color 200ms ease, transform 100ms ease-out;
   /* will-change: transform; */
   svg {
     display: block;
@@ -419,7 +444,7 @@ export const CloseButton = styled(motion.button)`
     background: var(--ck-body-background-secondary);
   }
   &:active {
-    transform: scale(0.9);
+    transform: scale(var(--ck-press-scale, 0.97));
   }
 `
 
@@ -436,7 +461,7 @@ const _SiweButton = styled(motion.button)`
   margin: 0;
   color: var(--ck-body-action-color);
   background: var(--ck-body-background);
-  transition: background-color 200ms ease, transform 100ms ease;
+  transition: background-color 200ms ease, transform 100ms ease-out;
   /* will-change: transform; */
   svg {
     display: block;
@@ -449,7 +474,7 @@ const _SiweButton = styled(motion.button)`
       background: var(--ck-body-background-secondary);
     }
     &:active {
-      transform: scale(0.9);
+      transform: scale(var(--ck-press-scale, 0.97));
     }
   }
 `
@@ -467,7 +492,7 @@ export const BackButton = styled(motion.button)`
   margin: 0;
   color: var(--ck-body-action-color);
   background: var(--ck-body-background);
-  transition: background-color 200ms ease, transform 100ms ease;
+  transition: background-color 200ms ease, transform 100ms ease-out;
   /* will-change: transform; */
   svg {
     display: block;
@@ -481,7 +506,7 @@ export const BackButton = styled(motion.button)`
       background: var(--ck-body-background-secondary);
     }
     &:active {
-      transform: scale(0.9);
+      transform: scale(var(--ck-press-scale, 0.97));
     }
   }
 `
@@ -500,7 +525,7 @@ export const InfoButton = styled(motion.button)`
   margin: 0;
   color: var(--ck-body-action-color);
   background: var(--ck-body-background);
-  transition: background-color 200ms ease, transform 100ms ease;
+  transition: background-color 200ms ease, transform 100ms ease-out;
   /* will-change: transform; */
   svg {
     display: block;
@@ -512,13 +537,13 @@ export const InfoButton = styled(motion.button)`
       background: var(--ck-body-background-secondary);
     }
     &:active {
-      transform: scale(0.9);
+      transform: scale(var(--ck-press-scale, 0.97));
     }
   }
 `
 
 export const Container = styled(motion.div)`
-  --ease: cubic-bezier(0.25, 0.1, 0.25, 1);
+  --ease: var(--ck-ease-out, cubic-bezier(0.23, 1, 0.32, 1));
   --duration: 200ms;
   --transition: height var(--duration) var(--ease),
     width var(--duration) var(--ease);

--- a/packages/openfort-react/src/components/Common/OTPInput/styles.ts
+++ b/packages/openfort-react/src/components/Common/OTPInput/styles.ts
@@ -96,7 +96,7 @@ export const OTPSlotWrapper = styled.div<{ isActive: boolean }>`
   align-items: center;
   justify-content: center;
 
-  transition: all 0.3s;
+  transition: border-color 200ms ease, background 200ms ease, outline-color 200ms ease;
 
   border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);

--- a/packages/openfort-react/src/components/Common/ThemedButton/styles.ts
+++ b/packages/openfort-react/src/components/Common/ThemedButton/styles.ts
@@ -15,8 +15,8 @@ export const Container = styled(motion.div)<{
   font-size: var(--ck-connectbutton-font-size, 16px);
   font-weight: var(--ck-connectbutton-font-weight, 500);
   text-align: center;
-  transition: 100ms ease;
-  transition-property: color, background, box-shadow, border-radius;
+  transition: 120ms ease-out;
+  transition-property: color, background, box-shadow, border-radius, transform;
 
   color: var(--color);
   background: var(--background);
@@ -144,6 +144,8 @@ export const ThemeContainer = styled.button`
         --active-border-radius,
         var(--hover-border-radius, var(--border-radius))
       );
+      /* Press feedback — the primary CTA must feel like it heard the tap. */
+      transform: scale(var(--ck-press-scale, 0.97));
     }
   }
   &:focus-visible {

--- a/packages/openfort-react/src/components/ConnectButton/index.tsx
+++ b/packages/openfort-react/src/components/ConnectButton/index.tsx
@@ -28,7 +28,7 @@ const contentVariants: Variants = {
     opacity: 1,
     x: 0.1,
     transition: {
-      duration: 0.4,
+      duration: 0.22,
       ease: [0.25, 1, 0.5, 1],
     },
   },
@@ -39,7 +39,7 @@ const contentVariants: Variants = {
     pointerEvents: 'none',
     position: 'absolute',
     transition: {
-      duration: 0.4,
+      duration: 0.22,
       ease: [0.25, 1, 0.5, 1],
     },
   },
@@ -55,7 +55,7 @@ const addressVariants: Variants = {
     x: 0.2,
     opacity: 1,
     transition: {
-      duration: 0.4,
+      duration: 0.22,
       ease: [0.25, 1, 0.5, 1],
     },
   },
@@ -66,7 +66,7 @@ const addressVariants: Variants = {
     pointerEvents: 'none',
     position: 'absolute',
     transition: {
-      duration: 0.4,
+      duration: 0.22,
       ease: [0.25, 1, 0.5, 1],
     },
   },
@@ -79,7 +79,7 @@ const textVariants: Variants = {
   animate: {
     opacity: 1,
     transition: {
-      duration: 0.3,
+      duration: 0.2,
       ease: [0.25, 1, 0.5, 1],
     },
   },
@@ -87,7 +87,7 @@ const textVariants: Variants = {
     position: 'absolute',
     opacity: 0,
     transition: {
-      duration: 0.3,
+      duration: 0.2,
       ease: [0.25, 1, 0.5, 1],
     },
   },
@@ -382,7 +382,7 @@ export function OpenfortButton({
                   width: 'auto',
                   marginRight: -24,
                   transition: {
-                    duration: 0.4,
+                    duration: 0.22,
                     ease: [0.25, 1, 0.5, 1],
                   },
                 }}
@@ -392,7 +392,7 @@ export function OpenfortButton({
                   width: 0,
                   marginRight: 0,
                   transition: {
-                    duration: 0.4,
+                    duration: 0.22,
                     ease: [0.25, 1, 0.5, 1],
                   },
                 }}

--- a/packages/openfort-react/src/components/Pages/Providers/styles.ts
+++ b/packages/openfort-react/src/components/Pages/Providers/styles.ts
@@ -9,7 +9,7 @@ export const ProviderInputInner = styled.div`
   border-radius: var(--ck-secondary-button-border-radius);
   font-size: 1rem;
   color: var(--ck-body-color);
-  transition: all 0.2s;
+  transition: background 200ms ease, box-shadow 200ms ease;
   width: 100%;
   height: 100%;
   display: flex;
@@ -69,7 +69,7 @@ export const ProviderInputInner = styled.div`
 
 export const EmailInnerButton = styled(motion.button)`
   color: var(--ck-body-action-color);
-  transition: background-color 200ms ease, transform 100ms ease, color 200ms ease, transition 200ms ease, opacity 200ms ease;
+  transition: background-color 200ms ease, transform 100ms ease-out, color 200ms ease, opacity 200ms ease;
   border-radius: 16px;
   
   svg {
@@ -85,7 +85,7 @@ export const EmailInnerButton = styled(motion.button)`
       color: var(--ck-body-action-hover-color);
     }
     &:active {
-      transform: scale(0.9);
+      transform: scale(var(--ck-press-scale, 0.97));
     }
   }
 `

--- a/packages/openfort-react/src/styles/index.ts
+++ b/packages/openfort-react/src/styles/index.ts
@@ -15,6 +15,11 @@ const themeGlobals = {
     'Segoe UI Symbol'`,
     '--ck-border-radius': '20px',
     '--ck-secondary-button-border-radius': '16px',
+    // Motion tokens — one source for easing/press feedback so the whole modal
+    // shares a vocabulary. Strong ease-out (the built-in CSS `ease` is too weak).
+    '--ck-ease-out': 'cubic-bezier(0.23, 1, 0.32, 1)',
+    '--ck-ease-in-out': 'cubic-bezier(0.77, 0, 0.175, 1)',
+    '--ck-press-scale': '0.97',
   },
   graphics: {
     light: {
@@ -323,14 +328,11 @@ export const ResetContainer = styled(motion.div)<{
     outline: none;
     border: none;
   }
-  /*
-  @media (prefers-reduced-motion) {
-    * {
-      animation-duration: 60ms !important;
-      transition-duration: 60ms !important;
-    }
-  }
-  */
+  /* Reduced motion is handled where movement actually happens — the modal
+     surfaces (Common/Modal/styles.ts) swap scale/slide for opacity-only fades,
+     and the connect button (ConnectButton) drops its horizontal slide — so
+     comprehension-aiding fades survive while vestibular-triggering motion is
+     removed (rather than a blanket duration:0 that kills the fades too). */
   img,
   svg {
     max-width: 100%;


### PR DESCRIPTION
A focused motion/interaction polish pass on the connect modal and shared controls, following Emil Kowalski's design-engineering principles.

## What changes

**Press feedback (highest-impact)**
- The primary `OpenfortButton` and the shared in-modal buttons ("Continue", "Review transfer", etc.) now scale on `:active`. Previously the main CTA gave **no** press feedback at all.
- Unified behind a `--ck-press-scale` token (was an inconsistent mix of `scale(0.9)` / `0.95` / `0.98`).

**Easing & motion vocabulary**
- New `--ck-ease-out` / `--ck-ease-in-out` tokens. The modal resize and page transitions now use a strong ease-out instead of the default-strength `ease` (which is the weakest possible curve).
- Press/state transitions switched from `ease` to `ease-out`.

**`transition: all` → explicit properties**
- Replaced across `Input`, `OTPInput`, `Button`, `Providers`, `Modal` and `CopyToClipboard` (avoids animating layout properties unintentionally).
- Removed a no-op `transition: transition` token in the email button.

**Timing & feel**
- Connect-button text swap sped up (400ms → 220ms; the slowest were over the 300ms UI threshold).
- Modal exit is now snappier than its enter (asymmetric timing).
- Subtle default backdrop blur so the modal separates from a busy page.

**Accessibility**
- `prefers-reduced-motion` now swaps the modal's scale/slide for opacity-only fades — keeps comprehension-aiding fades, drops the vestibular-triggering movement (rather than a blanket `duration: 0` that kills the fades too).

## Verification
Built and rendered locally in the `openfort-ui` example — modal renders cleanly, no regressions, backdrop blur applied. Type-checks clean.

## Deliberately out of scope (follow-ups)
- Converting the page-transition keyframes to interruptible CSS transitions (structural change to the modal's page orchestration).
- The `ThemedButton` width morph (transform-based would distort content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)