### PR TITLE
ci(release): unblock stuck release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,6 +23,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          # Fetch full git history so Changesets can resolve the commits behind
+          # each changeset and generate changelog entries correctly.
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
@@ -29,7 +34,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 24
+          # Pin the minor so the runner image can't drift onto a Node build that
+          # breaks node-fetch's gzip handling in the changelog generator.
+          node-version: 24.5
           cache: pnpm
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
## Problem

The **Release** workflow has failed deterministically since 6/30 (3 consecutive runs: #307, the #308 merge, and a manual re-run). Every failure is in the `changeset version` step:

```
generating changelog entries → FetchError: ...api.github.com/graphql: Premature close (ERR_STREAM_PREMATURE_CLOSE)
```

Consequence: no `chore: version package` PR is created and **nothing publishes** — npm is frozen at `1.6.2` with two patch changesets queued on `main` (`sdk-motion-polish`, `fix-sign-message-from-address`).

Ruled out: GitHub is healthy ("All Systems Operational"), the changeset config repo name is correct, and the `changesets/action` version is not at fault (it reproduces on our pinned v1.7.0 while older versions work elsewhere).

## Fix

- **`fetch-depth: 0`** — the shallow (depth-1) checkout can't resolve the commits behind pending changesets, feeding bad refs into the changelog GraphQL call.
- **`node-version` `24` → `24.5`** — pin the minor so the runner image can't drift onto a Node build that breaks `node-fetch`'s gzip handling in the changelog generator (matches the 6/27 → 6/30 regression window).
- **`workflow_dispatch`** — allow re-running the release on demand for recovery.

## After merge

The Release workflow re-runs on the merge with full history + pinned Node, should create the `chore: version package` PR, and publishing that PR ships **1.6.3** (motion polish + sign-message fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)