### PR TITLE
fix(modal): stop pages shifting sideways during route transitions

### DIFF
--- a/.changeset/fix-modal-transition-scrollbar-shift.md
+++ b/.changeset/fix-modal-transition-scrollbar-shift.md
@@ -1,0 +1,5 @@
+---
+"@openfort/react": patch
+---
+
+Fix modal content shifting sideways on every page change. During page transitions both pages stay mounted while the modal height animates, transiently overflowing the scrollable page area; wherever scrollbars consume layout width (Windows, macOS with a mouse connected, or host apps that style `::-webkit-scrollbar` globally) the flashing scrollbar shrank the width the centered pages resolve against, nudging all content left and back right on each route change. The page area no longer renders a scrollbar; pages taller than the viewport cap remain wheel/touch-scrollable.

--- a/packages/openfort-react/src/components/Common/Modal/styles.ts
+++ b/packages/openfort-react/src/components/Common/Modal/styles.ts
@@ -321,6 +321,17 @@ export const InnerContainer = styled(motion.div)`
   position: relative;
   overflow-x: hidden;
   overflow-y: auto;
+  /* Page transitions keep both pages mounted, so this container transiently
+     overflows while its height animates. A scrollbar must never render here:
+     wherever scrollbars consume layout width (Windows, macOS with a mouse,
+     host apps that style ::-webkit-scrollbar globally) it shrinks the width
+     that the left-50%-centered pages resolve against, shifting every page
+     sideways on each route change. Pages taller than the 88vh cap stay
+     wheel/touch-scrollable. */
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
   height: var(--height);
   /* Cap at the viewport so a tall page scrolls instead of running off-screen. */
   max-height: 88vh;


### PR DESCRIPTION
## Problem

On every modal page change (forward and back, all pages) the content visibly nudges sideways a few px and settles back — it looks like components "relocate themselves" after each navigation.

## Root cause

Page transitions keep both the entering and exiting page mounted while the modal height animates. The exiting page is absolutely positioned at its old height inside `InnerContainer`, whose height is transitioning to the new page's height — so the container transiently overflows on **every** transition, in both directions (measured `scrollHeight` 579px vs `clientHeight` 318px for ~350ms).

`InnerContainer` is `overflow-y: auto` and spans the full viewport width; pages are centered with `left: 50%` against its content box. Wherever scrollbars consume layout width — Windows, macOS with a mouse connected, or host apps that style `::-webkit-scrollbar` globally (the playground does exactly this) — the transient overflow flashes a scrollbar, the content box narrows by the scrollbar width, and the 50% reference point moves: all content shifts left ~6-8px and snaps back when the transition ends.

## Fix

Never render a scrollbar on `InnerContainer` (`scrollbar-width: none` plus `::-webkit-scrollbar { display: none }` for older WebKit). Pages taller than the 88vh cap remain wheel/touch-scrollable; the hidden scrollbar sat at the viewport edge rather than the card edge, so it carried no real affordance.

## Verification

Per-frame instrumentation of `getBoundingClientRect` during transitions in the playground, before and after:
- before: transient overflow + scrollbar-consuming environments shift page centers by half the scrollbar width
- after: `scrollbar-width` computes to `none` (beats host-app `* { scrollbar-width: thin }` on specificity), page centers stay at exactly viewport center on every animation frame in both directions, and a page taller than 88vh still scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)