### PR TITLE
fix(rpc): fall back to public RPCs for mainnet chains instead of throwing

### DIFF
--- a/.changeset/mainnet-rpc-fallback.md
+++ b/.changeset/mainnet-rpc-fallback.md
@@ -1,0 +1,5 @@
+---
+'@openfort/react': patch
+---
+
+Fall back to viem's public default RPCs for common mainnet chains (Ethereum, Base, Polygon, Optimism, Arbitrum, BNB, Beam) instead of throwing "No RPC URL configured". A one-time warning still nudges production apps toward `walletConfig.ethereum.rpcUrls`. Unknown chains without an explicit RPC keep throwing.

--- a/packages/openfort-react/src/__tests__/rpc.test.ts
+++ b/packages/openfort-react/src/__tests__/rpc.test.ts
@@ -1,0 +1,49 @@
+import { base, baseSepolia, bsc, mainnet } from 'viem/chains'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { logger } from '../utils/logger'
+import { buildChainFromConfig, getDefaultEthereumRpcUrl, isTestnetChainId } from '../utils/rpc'
+
+describe('buildChainFromConfig', () => {
+  const warn = vi.spyOn(logger, 'warn')
+
+  beforeEach(() => {
+    warn.mockClear()
+  })
+
+  it('returns the bundled viem chain for testnets without warning', () => {
+    expect(buildChainFromConfig(baseSepolia.id)).toBe(baseSepolia)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the public RPC for known mainnets and warns once', () => {
+    expect(buildChainFromConfig(base.id)).toBe(base)
+    buildChainFromConfig(base.id)
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]?.[0]).toContain(`rpcUrls[${base.id}]`)
+  })
+
+  it('uses the custom RPC without warning when provided', () => {
+    const chain = buildChainFromConfig(mainnet.id, { [mainnet.id]: 'https://rpc.example.com' })
+    expect(chain.rpcUrls.default.http[0]).toBe('https://rpc.example.com')
+    expect(chain.name).toBe(mainnet.name)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('still throws for chains without any known RPC', () => {
+    expect(() => buildChainFromConfig(999999)).toThrow('No RPC URL configured for chain 999999')
+  })
+})
+
+describe('isTestnetChainId', () => {
+  it('stays correct with mainnets bundled', () => {
+    expect(isTestnetChainId(baseSepolia.id)).toBe(true)
+    expect(isTestnetChainId(base.id)).toBe(false)
+    expect(isTestnetChainId(bsc.id)).toBe(false)
+  })
+})
+
+describe('getDefaultEthereumRpcUrl', () => {
+  it('returns the mainnet default RPC instead of falling back to sepolia', () => {
+    expect(getDefaultEthereumRpcUrl(base.id)).toBe(base.rpcUrls.default.http[0])
+  })
+})

--- a/packages/openfort-react/src/utils/rpc.ts
+++ b/packages/openfort-react/src/utils/rpc.ts
@@ -7,18 +7,54 @@
 
 import type { Chain } from 'viem'
 import { defineChain } from 'viem'
-import { arbitrumSepolia, baseSepolia, beamTestnet, optimismSepolia, polygonAmoy, sepolia } from 'viem/chains'
+import {
+  arbitrum,
+  arbitrumSepolia,
+  base,
+  baseSepolia,
+  beam,
+  beamTestnet,
+  bsc,
+  mainnet,
+  optimism,
+  optimismSepolia,
+  polygon,
+  polygonAmoy,
+  sepolia,
+} from 'viem/chains'
 import type { SolanaCluster } from '../solana/types'
 import { logger } from './logger'
 
 /** Known chains sourced from viem/chains — authoritative metadata (name, nativeCurrency, rpcUrls, blockExplorers). */
 const KNOWN_CHAINS: Record<number, Chain> = {
+  // Testnets
   [polygonAmoy.id]: polygonAmoy,
   [baseSepolia.id]: baseSepolia,
   [beamTestnet.id]: beamTestnet,
   [sepolia.id]: sepolia,
   [optimismSepolia.id]: optimismSepolia,
   [arbitrumSepolia.id]: arbitrumSepolia,
+  // Mainnets — the public default RPCs make apps work out of the box, but they
+  // are rate-limited; production apps should set walletConfig.ethereum.rpcUrls
+  // (a warning nudges them, see warnPublicRpcIfMainnet).
+  [mainnet.id]: mainnet,
+  [base.id]: base,
+  [polygon.id]: polygon,
+  [optimism.id]: optimism,
+  [arbitrum.id]: arbitrum,
+  [bsc.id]: bsc,
+  [beam.id]: beam,
+}
+
+const warnedPublicRpcChainIds = new Set<number>()
+
+/** Warn once per mainnet chain when the app is running on a public default RPC. */
+function warnPublicRpcIfMainnet(chain: Chain): void {
+  if (chain.testnet === true || warnedPublicRpcChainIds.has(chain.id)) return
+  warnedPublicRpcChainIds.add(chain.id)
+  logger.warn(
+    `Using the public default RPC for ${chain.name} (${chain.id}). Public endpoints are rate-limited — provide walletConfig.ethereum.rpcUrls[${chain.id}] in production.`
+  )
 }
 
 /** Testnets not in {@link KNOWN_CHAINS} but still worth recognizing (deprecated/uncommon). */
@@ -100,6 +136,7 @@ export function buildChainFromConfig(chainId: number, rpcUrls?: Record<number, s
   const knownChain = KNOWN_CHAINS[chainId]
 
   if (knownChain && !customRpcUrl) {
+    warnPublicRpcIfMainnet(knownChain)
     return knownChain
   }
 


### PR DESCRIPTION
## What

`KNOWN_CHAINS` in `utils/rpc.ts` only bundled testnet chains, so `OpenfortProvider` threw `No RPC URL configured for chain X` for any mainnet chain configured without explicit `walletConfig.ethereum.rpcUrls` — crashing the app on mount (this is what broke the live demo on the docs UI configuration page, chain 8453).

- Bundle the mainnet counterparts of the existing testnets from `viem/chains`: Ethereum, Base, Polygon, Optimism, Arbitrum, BNB, Beam. Named imports keep tree-shaking intact.
- When a mainnet chain runs on its public default RPC, log a one-time warning pointing at `walletConfig.ethereum.rpcUrls` (via the existing `logger`, so it surfaces under `debugMode` like the other RPC warnings).
- Chains viem doesn't bundle still throw the same error.
- `getDefaultEthereumRpcUrl` also benefits: mainnet chains now resolve their own default RPC instead of silently falling back to the Sepolia RPC.

## Tests

New `src/__tests__/rpc.test.ts`: mainnet fallback + warn-once, custom RPC override without warning, testnet passthrough, unknown-chain throw, `isTestnetChainId` unaffected. Full suite: 231 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)