### PR TITLE
fix(siwe): forward chainId on SIWE login

### DIFF
--- a/.changeset/siwe-send-chainid.md
+++ b/.changeset/siwe-send-chainid.md
@@ -1,0 +1,5 @@
+---
+"@openfort/react": patch
+---
+
+Forward the connected wallet's `chainId` on the SIWE login flow. `useWalletAuth` and `useConnectWithSiwe` now pass `chainId` to `initSiwe` and `loginWithSiwe`, so the chain ID in the signed SIWE message matches what the backend verifies. Without it the backend defaulted the request chain ID to `1`, failing verification on any other chain with `UNAUTHORIZED_SIWE_MESSAGE_MISMATCH`. Requires `@openfort/openfort-js` with `chainId` support on `initSiwe`/`loginWithSiwe`.

--- a/packages/openfort-react/src/wagmi/useConnectWithSiwe.ts
+++ b/packages/openfort-react/src/wagmi/useConnectWithSiwe.ts
@@ -82,7 +82,7 @@ export function useConnectWithSiwe() {
           const resp = await client.auth.initLinkSiwe({ address })
           nonce = resp.nonce
         } else {
-          const resp = await client.auth.initSiwe({ address })
+          const resp = await client.auth.initSiwe({ address, chainId })
           nonce = resp.nonce
         }
 
@@ -107,6 +107,7 @@ export function useConnectWithSiwe() {
             connectorType,
             walletClientType,
             address,
+            chainId,
           })
         }
 

--- a/packages/openfort-react/src/wagmi/useWalletAuth.ts
+++ b/packages/openfort-react/src/wagmi/useWalletAuth.ts
@@ -63,7 +63,7 @@ function runConnectWithSiwe(
       }
       const nonce = params.link
         ? (await client.auth.initLinkSiwe({ address })).nonce
-        : (await client.auth.initSiwe({ address })).nonce
+        : (await client.auth.initSiwe({ address, chainId })).nonce
       const siweMsg = createSIWEMessage(address, nonce, chainId)
       if (!siweMsg) throw new Error('SIWE message creation failed (window not available)')
       const messageStr =
@@ -89,6 +89,7 @@ function runConnectWithSiwe(
           connectorType,
           walletClientType,
           address,
+          chainId,
         })
       }
       await updateUser()


### PR DESCRIPTION
## Problem

External-wallet **SIWE login fails** with `401 UNAUTHORIZED_SIWE_MESSAGE_MISMATCH` on any non-mainnet chain (e.g. Base Sepolia `84532`).

`useWalletAuth` and `useConnectWithSiwe` build the SIWE message with the connected wallet's `chainId` (`createSIWEMessage(address, nonce, chainId)`) but never send that `chainId` to `initSiwe` / `loginWithSiwe`. The backend (better-auth `siwe` plugin) then defaults the request `chainId` to `1`. Since better-auth **1.6.x**, `/siwe/verify` compares the request `chainId` against the `Chain ID` embedded in the signed message and rejects the mismatch — `84532 !== 1`.

## Change

Both hooks now pass `chainId` to `initSiwe` and `loginWithSiwe` on the login/new-session path, so the nonce is keyed on the real chain and the verify chain-ID check passes. The link path (`initLinkSiwe` / `linkWithSiwe`) is unchanged.

## Depends on

**openfort-xyz/openfort-js#328** — adds `chainId` to `initSiwe` / `loginWithSiwe`. The published range here (`@openfort/openfort-js` `^1.3.9`) will pick up the release automatically; the lockfile just needs a refresh once it's out (that release is also what turns CI green here).

This is the client half of the fix. The remaining blocker is the API-side domain check (message `domain` must equal the plugin's hardcoded `domain`), tracked separately.

## Verification

`tsc -b` on the package: the two SIWE hook files typecheck cleanly against the post-#328 `openfort-js` types (verified locally by adding the `chainId?` param to the resolved decls). Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)