### PR TITLE
fix(ethereum): pass configured rpcUrls when create() builds the embedded provider

### DIFF
--- a/.changeset/lucky-otters-wander.md
+++ b/.changeset/lucky-otters-wander.md
@@ -1,0 +1,5 @@
+---
+'@openfort/react': patch
+---
+
+Pass `walletConfig.ethereum.rpcUrls` when the embedded Ethereum provider is built during wallet creation. The SDK memoizes the provider on its first caller, and during `create()` that caller is `useEthereumEmbeddedWallet` — `EthereumEmbeddedStrategy.initProvider`, the only path that supplied the endpoints, is gated on `EmbeddedState.READY`, which a wallet still being created hasn't reached. The session was therefore pinned to the SDK's public default endpoints, whose chain fallback is Base mainnet regardless of the configured chain, which showed up as intermittent `could not detect network` failures during wallet creation.

--- a/examples/playground/src/lib/chains.ts
+++ b/examples/playground/src/lib/chains.ts
@@ -21,7 +21,10 @@ export const PLAYGROUND_EVM_CHAINS: PlaygroundEvmChain[] = [
   {
     id: polygonAmoy.id,
     name: 'Polygon Amoy',
-    rpcUrl: 'https://rpc-amoy.polygon.technology',
+    // polygon.technology's public Amoy endpoint went dark (empty replies) and the
+    // SDK's provider init retries detectNetwork against it forever, so the wallet
+    // never connects — publicnode matches the other chains' endpoints here.
+    rpcUrl: 'https://polygon-amoy-bor-rpc.publicnode.com',
     explorerUrl: 'https://amoy.polygonscan.com',
     viemChain: polygonAmoy,
   },

--- a/examples/playground/tests/pages/dashboard.page.ts
+++ b/examples/playground/tests/pages/dashboard.page.ts
@@ -78,7 +78,15 @@ export class DashboardPage {
   }
 
   async getCardByTitle(title: string | RegExp) {
-    const titleLocator = this.page.locator('[data-slot="card"]').filter({ hasText: title }).first()
+    // Match the card TITLE slot, not any text in the card: body copy can
+    // legitimately contain another card's title word (e.g. the Session keys
+    // card's "EOA wallets cannot use session keys" note matches /wallets/i once
+    // the shared test account has a wallet), and `hasText` + `.first()` would
+    // then grab the wrong card and strand the spec.
+    const titleLocator = this.page
+      .locator('[data-slot="card"]')
+      .filter({ has: this.page.locator('[data-slot="card-title"]', { hasText: title }) })
+      .first()
 
     await expect(titleLocator).toBeVisible({ timeout: 10_000 })
 

--- a/packages/openfort-react/src/__tests__/useEthereumEmbeddedWallet.create.test.ts
+++ b/packages/openfort-react/src/__tests__/useEthereumEmbeddedWallet.create.test.ts
@@ -353,6 +353,34 @@ describe('useEthereumEmbeddedWallet – create', () => {
     expect(mockUpdateEmbeddedAccounts).toHaveBeenCalledWith({ silent: true })
   })
 
+  it('forwards the configured RPC endpoints when building the provider', async () => {
+    // create() is the first caller of getEthereumProvider — EthereumEmbeddedStrategy
+    // .initProvider is gated on EmbeddedState.READY, which a wallet being created
+    // hasn't reached — and the SDK memoizes the provider on its first caller. Calling
+    // it with no options pinned the session to the SDK's public default endpoints,
+    // whose chain fallback is Base mainnet regardless of the app's configured chain.
+    const rpcUrls = { 84532: 'https://base-sepolia.example' }
+    const mockOpenfortUI = await import('../components/Openfort/useOpenfort')
+    const spy = vi.spyOn(mockOpenfortUI, 'useOpenfortUIContext').mockReturnValue({
+      walletConfig: createMockWalletConfig({
+        ethereum: { accountType: AccountTypeEnum.SMART_ACCOUNT, rpcUrls },
+      }),
+      chainType: ChainTypeEnum.EVM,
+    } as ReturnType<typeof mockOpenfortUI.useOpenfortUIContext>)
+
+    mockClient.embeddedWallet.create.mockResolvedValueOnce(createMockEmbeddedAccount())
+
+    const { result } = renderHook(() => useEthereumEmbeddedWallet(), { wrapper: createTestWrapper() })
+
+    await act(async () => {
+      await result.current.create()
+    })
+
+    expect(mockClient.embeddedWallet.getEthereumProvider).toHaveBeenCalledWith({ chains: rpcUrls })
+
+    spy.mockRestore()
+  })
+
   it('defaults accountType from walletConfig.ethereum when not specified', async () => {
     const account = createMockEmbeddedAccount({ accountType: AccountTypeEnum.SMART_ACCOUNT })
     mockClient.embeddedWallet.create.mockResolvedValueOnce(account)

--- a/packages/openfort-react/src/ethereum/hooks/useEthereumEmbeddedWallet.ts
+++ b/packages/openfort-react/src/ethereum/hooks/useEthereumEmbeddedWallet.ts
@@ -113,14 +113,22 @@ export function useEthereumEmbeddedWallet(options?: UseEmbeddedEthereumWalletOpt
   ethereumAccountsRef.current = ethereumAccounts
 
   const getEmbeddedEthereumProvider = useCallback(async (): Promise<OpenfortEmbeddedEthereumWalletProvider> => {
-    const provider = await client.embeddedWallet.getEthereumProvider()
+    // The SDK memoizes the provider on its first caller, so the configured RPC
+    // endpoints have to be passed here too. EthereumEmbeddedStrategy.initProvider
+    // is the only other caller that passes them, and it is gated on
+    // EmbeddedState.READY — which a wallet still being created has not reached.
+    // So create() gets here first and would otherwise pin the whole session to
+    // the SDK's public default endpoints.
+    const provider = await client.embeddedWallet.getEthereumProvider({
+      chains: walletConfig?.ethereum?.rpcUrls,
+    })
     // Ensure the current account is authorized on the provider.
     // Without this, signing after password recovery can fail with
     // "Unauthorized - call eth_requestAccounts first" because the provider
     // was obtained before initProvider ran with proper config.
     await provider.request({ method: 'eth_requestAccounts' })
     return provider as OpenfortEmbeddedEthereumWalletProvider
-  }, [client])
+  }, [client, walletConfig?.ethereum?.rpcUrls])
 
   const wallets = useMemo<ConnectedEmbeddedEthereumWallet[]>(() => {
     const uniqueAddresses = new Map<string, EmbeddedAccount>()


### PR DESCRIPTION
## Problem

`getEmbeddedEthereumProvider` called `client.embeddedWallet.getEthereumProvider()` with no options, so `walletConfig.ethereum.rpcUrls` never reached the SDK.

That matters because the SDK memoizes the provider on its first caller. `EthereumEmbeddedStrategy.initProvider` is the only path that passes the endpoints, and it's gated on `EmbeddedState.READY` — which a wallet still being created hasn't reached. So during `create()` this hook gets there first, and the session is pinned to the SDK's public default endpoints for its whole lifetime.

With no chains configured the SDK's chain resolution also falls through to Base mainnet on the shared public endpoint, regardless of the chain the app is on. Reported symptom: intermittent `could not detect network (event="noNetwork", code=NETWORK_ERROR)` on wallet creation, most often on Safari.

## Change

Pass `chains: walletConfig?.ethereum?.rpcUrls` in `getEmbeddedEthereumProvider`, and add `rpcUrls` to the `useCallback` deps so a config change isn't served a stale closure.

## Tests

One added to `useEthereumEmbeddedWallet.create.test.ts`, verified to fail against the unpatched hook (stashed the source change, kept the test): after `create()`, `getEthereumProvider` was called with the configured `chains`. `232/232` pass, `tsc --noEmit` clean, `biome check` clean. Changeset added (patch).

## Related

openfort-xyz/openfort-js#343 removes the network probe that turned this misconfiguration into a hard wallet-creation failure. This PR is the other half: it stops the provider being built against the wrong endpoints in the first place, which also affects the paths that genuinely need RPC (`eth_sendTransaction`, `signTypedDataV4`).

## Noted, not fixed here

`EthereumEmbeddedStrategy.ts:66` spreads `resolveEthereumFeeSponsorship()`'s `{ policy }` into an options object whose field is `feeSponsorship`, so fee sponsorship never reaches the provider. Separate bug, left alone to keep this diff narrow.

Prompted by: Joan Alavedra