### PR TITLE
fix(buy): reserve the onramp popup inside the click handler

### DIFF
--- a/.changeset/fix-onramp-popup-blocked.md
+++ b/.changeset/fix-onramp-popup-blocked.md
@@ -1,0 +1,5 @@
+---
+"@openfort/react": patch
+---
+
+Fix "Failed to create payment session" when buying with card on Safari. The onramp popup was opened after the session request resolved, by which point the browser's transient user activation had expired — Safari blocks `window.open` after ~0.5s — so a successfully created session was reported as a payment failure. The provider window is now reserved synchronously inside the Continue click and navigated once the session resolves. If the browser still refuses the window, a "Popup blocked" screen offers a click-through instead of a false error.

--- a/packages/openfort-react/src/components/Pages/Buy/buyPopup.test.ts
+++ b/packages/openfort-react/src/components/Pages/Buy/buyPopup.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { closeBuyPopup, navigateBuyPopup, reserveBuyPopup, takeBuyPopup } from './buyPopup'
+
+const fakePopup = () => ({
+  closed: false,
+  close: vi.fn(function (this: { closed: boolean }) {
+    this.closed = true
+  }),
+  document: { write: vi.fn(), close: vi.fn() },
+  location: { href: '' },
+})
+
+const stubOpen = (result: unknown) => vi.spyOn(window, 'open').mockReturnValue(result as Window)
+
+afterEach(() => {
+  closeBuyPopup()
+  vi.restoreAllMocks()
+})
+
+describe('reserveBuyPopup', () => {
+  it('opens about:blank so the window is claimed inside the user gesture', () => {
+    const popup = fakePopup()
+    const open = stubOpen(popup)
+
+    expect(reserveBuyPopup()).toBe(popup)
+    expect(open).toHaveBeenCalledWith('', 'BuyPopup', expect.stringContaining('width=500'))
+    // Empty URL: navigation happens later, once the onramp session resolves.
+    expect(open.mock.calls[0][0]).toBe('')
+  })
+
+  it('returns null when the popup blocker refuses the window', () => {
+    stubOpen(null)
+    expect(reserveBuyPopup()).toBeNull()
+    expect(takeBuyPopup()).toBeNull()
+  })
+
+  it('closes a previously reserved window instead of leaking it', () => {
+    const first = fakePopup()
+    stubOpen(first)
+    reserveBuyPopup()
+
+    stubOpen(fakePopup())
+    reserveBuyPopup()
+
+    expect(first.close).toHaveBeenCalled()
+  })
+})
+
+describe('takeBuyPopup', () => {
+  it('hands over the reserved window exactly once', () => {
+    const popup = fakePopup()
+    stubOpen(popup)
+    reserveBuyPopup()
+
+    expect(takeBuyPopup()).toBe(popup)
+    expect(takeBuyPopup()).toBeNull()
+  })
+
+  it('discards a window the user already closed', () => {
+    const popup = fakePopup()
+    stubOpen(popup)
+    reserveBuyPopup()
+    popup.closed = true
+
+    expect(takeBuyPopup()).toBeNull()
+  })
+
+  it('returns null when nothing was reserved', () => {
+    expect(takeBuyPopup()).toBeNull()
+  })
+})
+
+describe('navigateBuyPopup', () => {
+  it('points the reserved window at the provider url', () => {
+    const popup = fakePopup()
+    expect(navigateBuyPopup(popup as unknown as Window, 'https://pay.coinbase.com/buy')).toBe(true)
+    expect(popup.location.href).toBe('https://pay.coinbase.com/buy')
+  })
+
+  it('reports failure instead of throwing when the window is gone', () => {
+    const popup = {
+      get location(): Location {
+        throw new Error('window closed')
+      },
+    }
+    expect(navigateBuyPopup(popup as unknown as Window, 'https://pay.coinbase.com/buy')).toBe(false)
+  })
+})

--- a/packages/openfort-react/src/components/Pages/Buy/buyPopup.ts
+++ b/packages/openfort-react/src/components/Pages/Buy/buyPopup.ts
@@ -1,0 +1,77 @@
+const POPUP_NAME = 'BuyPopup'
+const POPUP_WIDTH = 500
+const POPUP_HEIGHT = 700
+
+// Held outside React: a WindowProxy is imperative handle state, and parking it in
+// context/state would re-render the tree every time the popup is opened or cleared.
+let pendingPopup: Window | null = null
+
+const isUsable = (popup: Window | null): popup is Window => !!popup && !popup.closed
+
+export const buyPopupFeatures = (): string => {
+  const dualScreenLeft = window.screenLeft !== undefined ? window.screenLeft : window.screenX
+  const dualScreenTop = window.screenTop !== undefined ? window.screenTop : window.screenY
+  const width = window.innerWidth || document.documentElement.clientWidth || screen.width
+  const height = window.innerHeight || document.documentElement.clientHeight || screen.height
+  const left = width / 2 - POPUP_WIDTH / 2 + dualScreenLeft
+  const top = height / 2 - POPUP_HEIGHT / 2 + dualScreenTop
+
+  return `scrollbars=yes,width=${POPUP_WIDTH},height=${POPUP_HEIGHT},top=${top},left=${left}`
+}
+
+/**
+ * Opens the provider window while the browser's transient user activation is still
+ * live. Browsers only honour `window.open` for a short window after the originating
+ * click — roughly 0.5s in Safari, 1s in Chrome and Firefox — and creating an onramp
+ * session takes longer than that, so opening the window after the `await` gets it
+ * blocked and `window.open` returns null. Reserve it up front on `about:blank` and
+ * point it at the provider once the session resolves.
+ *
+ * Must be called synchronously from a user gesture handler.
+ */
+export const reserveBuyPopup = (): Window | null => {
+  if (typeof window === 'undefined') return null
+
+  closeBuyPopup()
+  const popup = window.open('', POPUP_NAME, buyPopupFeatures())
+
+  if (popup) {
+    try {
+      // about:blank inherits the opener's origin, so this is same-origin until we
+      // navigate to the provider. Purely cosmetic — never block the flow on it.
+      popup.document.write('<!doctype html><title>Connecting…</title>')
+      popup.document.close()
+    } catch {
+      // Ignore: some browsers restrict writing to about:blank.
+    }
+  }
+
+  pendingPopup = popup
+  return popup
+}
+
+/** Hands the reserved window to the caller, which becomes responsible for it. */
+export const takeBuyPopup = (): Window | null => {
+  const popup = pendingPopup
+  pendingPopup = null
+  return isUsable(popup) ? popup : null
+}
+
+export const closeBuyPopup = (): void => {
+  if (isUsable(pendingPopup)) pendingPopup.close()
+  pendingPopup = null
+}
+
+/**
+ * Navigates an already-open window to the provider. Cross-origin navigation of a
+ * window you opened is allowed (reading its location later is not), but a window
+ * closed by the user in the meantime will throw.
+ */
+export const navigateBuyPopup = (popup: Window, url: string): boolean => {
+  try {
+    popup.location.href = url
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/openfort-react/src/components/Pages/BuyProcessing/index.tsx
+++ b/packages/openfort-react/src/components/Pages/BuyProcessing/index.tsx
@@ -14,6 +14,7 @@ import SquircleSpinner from '../../Common/SquircleSpinner'
 import { routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
+import { buyPopupFeatures, closeBuyPopup, navigateBuyPopup, takeBuyPopup } from '../Buy/buyPopup'
 import { createCoinbaseSession } from '../Buy/coinbaseApi'
 import { resolveOnrampNetwork } from '../Buy/onrampApi'
 import { SOLANA_BUY_CURRENCIES } from '../Buy/solanaCurrencies'
@@ -39,6 +40,8 @@ const BuyProcessing = () => {
   const [showContinueButton, setShowContinueButton] = useState(false)
   const [isCreatingSession, setIsCreatingSession] = useState(true)
   const [sessionError, setSessionError] = useState(false)
+  // Set when the session exists but the browser refused to open a window for it.
+  const [blockedProviderUrl, setBlockedProviderUrl] = useState<string | null>(null)
 
   const { data: ethAssets } = useEthereumWalletAssets()
   const assets = chainType === ChainTypeEnum.SVM ? SOLANA_BUY_CURRENCIES : ethAssets
@@ -67,7 +70,11 @@ const BuyProcessing = () => {
     sessionStartedRef.current = true
 
     const createSessionAndOpenPopup = async () => {
+      // Claimed up front so every exit path below can close it.
+      const reservedPopup = takeBuyPopup()
+
       if (!fiatAmount || fiatAmount <= 0) {
+        if (reservedPopup) reservedPopup.close()
         setRoute(routes.BUY_SELECT_PROVIDER)
         return
       }
@@ -104,6 +111,7 @@ const BuyProcessing = () => {
         }
 
         if (!onrampUrl) {
+          if (reservedPopup) reservedPopup.close()
           setSessionError(true)
           return
         }
@@ -114,37 +122,28 @@ const BuyProcessing = () => {
         url.searchParams.delete('fiatCurrency')
         const sanitizedProviderUrl = url.toString()
 
-        if (typeof window !== 'undefined') {
-          const popupWidth = 500
-          const popupHeight = 700
-          const dualScreenLeft = window.screenLeft !== undefined ? window.screenLeft : window.screenX
-          const dualScreenTop = window.screenTop !== undefined ? window.screenTop : window.screenY
-          const width = window.innerWidth
-            ? window.innerWidth
-            : document.documentElement.clientWidth
-              ? document.documentElement.clientWidth
-              : screen.width
-          const height = window.innerHeight
-            ? window.innerHeight
-            : document.documentElement.clientHeight
-              ? document.documentElement.clientHeight
-              : screen.height
-          const left = width / 2 - popupWidth / 2 + dualScreenLeft
-          const top = height / 2 - popupHeight / 2 + dualScreenTop
+        if (typeof window === 'undefined') return
 
-          const popup = window.open(
-            sanitizedProviderUrl,
-            'BuyPopup',
-            `scrollbars=yes,width=${popupWidth},height=${popupHeight},top=${top},left=${left}`
-          )
-
-          if (popup) {
-            setPopupWindow(popup)
-          } else {
-            setSessionError(true)
-          }
+        if (reservedPopup && navigateBuyPopup(reservedPopup, sanitizedProviderUrl)) {
+          setPopupWindow(reservedPopup)
+          return
         }
+
+        // No usable window: either the user dismissed it, or the popup blocker took
+        // it despite the gesture. Retry inline — this still succeeds when the session
+        // resolved fast enough to stay inside the activation window.
+        const popup = window.open(sanitizedProviderUrl, 'BuyPopup', buyPopupFeatures())
+
+        if (popup) {
+          setPopupWindow(popup)
+          return
+        }
+
+        // Give up on opening it ourselves and let the user click through. A click
+        // handler always carries a fresh activation, so that open cannot be blocked.
+        setBlockedProviderUrl(sanitizedProviderUrl)
       } catch (_error) {
+        if (reservedPopup) reservedPopup.close()
         setSessionError(true)
       } finally {
         setIsCreatingSession(false)
@@ -152,12 +151,17 @@ const BuyProcessing = () => {
     }
 
     createSessionAndOpenPopup()
+
+    // Closes the reserved window only while it is still unclaimed — once
+    // createSessionAndOpenPopup takes it, this is a no-op and the popup the user is
+    // paying in survives. Covers backing out before the wallet was ready to start.
+    return closeBuyPopup
   }, [address, network]) // Run when wallet becomes ready
 
   // Trigger resize on mount and when state changes
   useEffect(() => {
     triggerResize()
-  }, [triggerResize, isCreatingSession, showContinueButton, sessionError])
+  }, [triggerResize, isCreatingSession, showContinueButton, sessionError, blockedProviderUrl])
 
   // Show continue button after 2 seconds
   useEffect(() => {
@@ -258,6 +262,34 @@ const BuyProcessing = () => {
   const isStripe = buyForm.providerId === 'stripe'
   const isCoinbase = buyForm.providerId === 'coinbase'
   const isProvider = isStripe || isCoinbase
+
+  if (blockedProviderUrl) {
+    const openBlockedProvider = () => {
+      const popup = window.open(blockedProviderUrl, 'BuyPopup', buyPopupFeatures())
+      if (popup) {
+        setBlockedProviderUrl(null)
+        setPopupWindow(popup)
+      }
+    }
+
+    return (
+      <PageContent onBack={handleBack}>
+        <ModalContent style={{ paddingBottom: 18, textAlign: 'center' }}>
+          <ModalHeading>Popup blocked</ModalHeading>
+          <ModalBody>
+            Your payment is ready, but your browser blocked the {isStripe ? 'Stripe' : 'Coinbase'} window.
+            <br />
+            Allow popups for this site, or continue below.
+          </ModalBody>
+          <ContinueButtonWrapper style={{ marginTop: 24 }}>
+            <Button variant="primary" onClick={openBlockedProvider}>
+              Continue to {isStripe ? 'Stripe' : 'Coinbase'}
+            </Button>
+          </ContinueButtonWrapper>
+        </ModalContent>
+      </PageContent>
+    )
+  }
 
   if (isCreatingSession) {
     return (

--- a/packages/openfort-react/src/components/Pages/BuySelectProvider/index.tsx
+++ b/packages/openfort-react/src/components/Pages/BuySelectProvider/index.tsx
@@ -12,6 +12,7 @@ import { ModalBody, ModalHeading } from '../../Common/Modal/styles'
 import { routes } from '../../Openfort/types'
 import { useOpenfort } from '../../Openfort/useOpenfort'
 import { PageContent } from '../../PageContent'
+import { reserveBuyPopup } from '../Buy/buyPopup'
 import { isCoinbaseSupported } from '../Buy/coinbaseApi'
 import type { OnrampQuote } from '../Buy/onrampApi'
 import { getAllQuotes, resolveOnrampNetwork } from '../Buy/onrampApi'
@@ -174,6 +175,10 @@ const BuySelectProvider = () => {
   }
 
   const handleContinue = () => {
+    // Reserve the provider window here, inside the click handler, while the browser
+    // still treats this as user-activated. BuyProcessing navigates it once the onramp
+    // session resolves — by then the activation has expired and window.open is blocked.
+    reserveBuyPopup()
     setRoute(routes.BUY_PROCESSING)
   }
 


### PR DESCRIPTION
## What happened

A user on the [Funding docs page](https://www.openfort.io/docs/products/embedded-wallet/react/ui/configuration#funding) hit `Failed to create payment session. Please try again` from both the **Fund your wallet** and **Buy with Card** modals.

The backend was fine. In the incident window (2026-08-03 11:53–12:07 UTC, project `docs wallet` 3601 / env 5905):

- 10 × `POST /v1/onramp/sessions` — **all HTTP 200** in ~180ms, each returning a valid `onrampUrl`
- 63/63 requests for that project were 200. Zero server errors.
- Every attempt came from iOS 18.7 Safari. The same flow from macOS Chrome 90 minutes later, on the same API pods, worked end to end.

## Root cause

`BuyProcessing` called `window.open` *after* `await createCoinbaseSession(...)`:

```ts
const session = await createCoinbaseSession({ ... })   // ~180ms, plus wallet/asset load
const popup = window.open(sanitizedProviderUrl, 'BuyPopup', ...)
if (popup) setPopupWindow(popup)
else setSessionError(true)                             // → "Failed to create payment session."
```

Browsers only honour `window.open` while transient user activation is live — [~0.5s in Safari, ~1s in Chrome/Firefox](https://dontpaniclabs.com/blog/post/2025/07/29/understanding-window-open-behavior-on-ios-safari/). By then it has expired, `window.open` returns `null`, and the `else` branch reported a payment failure for a session that was created successfully.

This is a latent bug on **every** browser, not an iOS quirk. It reproduced on iOS Safari because that has the tightest budget; desktop Chrome usually squeaked in under the wire.

## The fix

Reserve the window synchronously in the Continue click handler, navigate it once the session resolves — the standard pre-open pattern.

- `Buy/buyPopup.ts` — reserve on `about:blank` during the gesture, hand off, navigate, close.
- `BuySelectProvider` — `reserveBuyPopup()` in `handleContinue`, which is a real `onClick`.
- `BuyProcessing` — claim the reserved window and set its location. Falls back to an inline `window.open` (still works when the session resolved fast), then to a **Popup blocked** screen with a click-through, which always carries a fresh activation.
- A blocked popup no longer reports as a failed payment session.
- Unclaimed reserved windows are closed on unmount, so backing out early doesn't leak an `about:blank` tab.

## Browser validation

| Browser | Before | After |
|---|---|---|
| iOS Safari | blocked after ~0.5s → error | reserved during gesture → opens |
| macOS Safari | same ~0.5s budget, raced it | same |
| Chrome / Edge | ~1s budget, usually passed | no longer timing-dependent |
| Firefox | blocks non-gesture opens | reserved during gesture → opens |

Strictly safer everywhere: the reserved window is opened earlier in the same gesture that already worked, and both previous behaviours remain as fallbacks.

## Testing

- 8 new unit tests in `buyPopup.test.ts` covering reserve/hand-off/blocked/closed-by-user/navigation-failure.
- Full package suite green: 34 files, 240 tests.
- `biome check` clean; `tsc --noEmit` reports no errors in package source.

Not verified in a real iOS Safari session — the reasoning and the log evidence line up, but a device check before release would be worth it.

## Follow-up (separate issue)

There was no Sentry data to corroborate this. `Sentry.init` exists in exactly one Openfort repo (`iframe`); `openfort-react`, `documentation`, `www` and `api` are uninstrumented, so a client-side failure like this is invisible.

Prompted by: Joan Alavedra