### PR TITLE
fix(release): keep changeset publish away from the backend template

### DIFF
--- a/packages/create-openfort/template/backend/package.json
+++ b/packages/create-openfort/template/backend/package.json
@@ -1,5 +1,7 @@
 {
   "name": "auth-sample-backend",
+  "private": true,
+  "version": "0.0.0",
   "packageManager": "pnpm@9.15.4",
   "dependencies": {
     "@openfort/openfort-node": "^0.7.1",

--- a/scripts/test-release-contract.mjs
+++ b/scripts/test-release-contract.mjs
@@ -53,6 +53,18 @@ assert.deepEqual(
   "Private templates and examples must stay outside release version plans.",
 );
 
+// The backend template depends on no released package, so it never appears in
+// the release plan below — `private` is the only thing keeping publish away
+// from it. Without it the canary publish fails on the versionless manifest.
+const backendTemplate = JSON.parse(
+  readFileSync("packages/create-openfort/template/backend/package.json", "utf8"),
+);
+assert.equal(
+  backendTemplate.private,
+  true,
+  "The backend template must stay private or changeset publish will try to release it.",
+);
+
 const statusDirectory = mkdtempSync(join(tmpdir(), "openfort-react-changeset-status-"));
 const statusPath = join(statusDirectory, "status.json");
 try {


### PR DESCRIPTION
Replaces #328, which carried the pre-squash history of #322 and conflicted with main. Single commit on top of current main.

## Summary

The canary publish job on main fails with `ERR_PNPM_PACKAGE_VERSION_NOT_FOUND`: `packages/create-openfort/template/backend` is a workspace member (`packages/**`) but its manifest had neither `private` nor a `version`, so `changeset publish --snapshot canary` tried to release `auth-sample-backend@undefined`.

- Mark the backend template `"private": true` with a `0.0.0` version, matching the four frontend templates. `changeset publish` skips private workspaces, so the canary job no longer attempts it.
- Extend `scripts/test-release-contract.mjs` to assert the manifest stays private. The template depends on no released package, so it never appears in the `changeset status` plan the existing gate inspects — the manifest check is the only guard that covers it.

Scaffolded backends now carry `private: true`/`version: 0.0.0`, which also prevents an accidental `npm publish` from a user project.

## Verification

`pnpm check:release`, `pnpm check:repo`, `pnpm check`, and the create-openfort test suite (43 passing) all green on top of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)