### PR TITLE
fix(release): tolerate the version branch in the release-contract gate

### DIFF
--- a/scripts/test-release-contract.mjs
+++ b/scripts/test-release-contract.mjs
@@ -67,37 +67,53 @@ assert.equal(
 
 const statusDirectory = mkdtempSync(join(tmpdir(), "openfort-react-changeset-status-"));
 const statusPath = join(statusDirectory, "status.json");
+let statusAvailable = true;
 try {
-  execFileSync("pnpm", ["exec", "changeset", "status", "--output", statusPath], {
-    cwd: process.cwd(),
-    stdio: "pipe",
-  });
-  const status = JSON.parse(readFileSync(statusPath, "utf8"));
-  // `changeset status` lists every workspace, so the invariant is not absence
-  // from the plan: it is that these workspaces never take a version bump.
-  const privateWorkspaces = [
-    "create-openfort-template-firebase",
-    "create-openfort-template-headless",
-    "create-openfort-template-openfort-ui",
-    "create-openfort-template-solana-headless",
-    "quickstart-solana-headless",
-  ];
-  for (const name of privateWorkspaces) {
-    const release = status.releases.find((entry) => entry.name === name);
-    assert.ok(
-      release,
-      `${name} is missing from the release plan, so this gate no longer covers it.`,
+  try {
+    execFileSync("pnpm", ["exec", "changeset", "status", "--output", statusPath], {
+      cwd: process.cwd(),
+      stdio: "pipe",
+    });
+  } catch (error) {
+    const stderr = error.stderr?.toString() ?? "";
+    // On the changeset-release branch the version PR has already consumed the
+    // changesets, so `changeset status` exits with this complaint by design.
+    // There is no release plan to inspect there; the config and manifest
+    // assertions above still ran.
+    if (!stderr.includes("no changesets were found")) throw error;
+    statusAvailable = false;
+    console.log(
+      "No pending changesets (version branch); skipping the release-plan assertions.",
     );
-    assert.equal(
-      release.type,
-      "none",
-      `Changesets must not version the private workspace ${name}.`,
-    );
-    assert.equal(
-      release.newVersion,
-      release.oldVersion,
-      `Changesets must not bump the private workspace ${name}.`,
-    );
+  }
+  if (statusAvailable) {
+    const status = JSON.parse(readFileSync(statusPath, "utf8"));
+    // `changeset status` lists every workspace, so the invariant is not absence
+    // from the plan: it is that these workspaces never take a version bump.
+    const privateWorkspaces = [
+      "create-openfort-template-firebase",
+      "create-openfort-template-headless",
+      "create-openfort-template-openfort-ui",
+      "create-openfort-template-solana-headless",
+      "quickstart-solana-headless",
+    ];
+    for (const name of privateWorkspaces) {
+      const release = status.releases.find((entry) => entry.name === name);
+      assert.ok(
+        release,
+        `${name} is missing from the release plan, so this gate no longer covers it.`,
+      );
+      assert.equal(
+        release.type,
+        "none",
+        `Changesets must not version the private workspace ${name}.`,
+      );
+      assert.equal(
+        release.newVersion,
+        release.oldVersion,
+        `Changesets must not bump the private workspace ${name}.`,
+      );
+    }
   }
 } finally {
   rmSync(statusDirectory, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

The "Run pnpm build" check fails on version PR #327 at the "Check release template gate" step. The gate (`scripts/test-release-contract.mjs`, added in #322, first exercised by #327) runs `changeset status`, which exits non-zero on `changeset-release/main` **by design**: the version PR has already consumed the changeset files and bumped versions, so changesets sees changed packages with no changesets and errors.

Skip the release-plan assertions when `changeset status` reports no pending changesets. The script/workflow/config assertions and the backend-template `private` manifest check still run in every state.

## Verification

- On main: `pnpm check:release` passes with the full release-plan assertions.
- On `changeset-release/main` (reproduced locally, same failure as CI): the fixed gate prints the skip notice and passes.

Once merged, changesets refreshes `changeset-release/main` on top of main, so #327 picks up the fixed gate automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)