### PR TITLE
Update openfort-js to 2.1.0

### DIFF
--- a/.changeset/bright-ravens-update.md
+++ b/.changeset/bright-ravens-update.md
@@ -1,0 +1,5 @@
+---
+"@openfort/react": patch
+---
+
+Updated @openfort/openfort-js to 2.1.0.

--- a/packages/openfort-react/package.json
+++ b/packages/openfort-react/package.json
@@ -91,7 +91,7 @@
     "react"
   ],
   "dependencies": {
-    "@openfort/openfort-js": "^1.6.0",
+    "@openfort/openfort-js": "^2.1.0",
     "buffer": "^6.0.3",
     "detect-browser": "^5.3.0",
     "fast-password-entropy": "^1.1.1",

--- a/packages/openfort-react/src/components/Openfort/OpenfortProvider.tsx
+++ b/packages/openfort-react/src/components/Openfort/OpenfortProvider.tsx
@@ -1,11 +1,6 @@
 'use client'
 
-import {
-  ChainTypeEnum,
-  RecoveryMethod,
-  type SDKOverrides,
-  type ThirdPartyAuthConfiguration,
-} from '@openfort/openfort-js'
+import { ChainTypeEnum, RecoveryMethod, type ThirdPartyAuthConfiguration } from '@openfort/openfort-js'
 import type React from 'react'
 import { lazy, Suspense, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { DEFAULT_DEV_CHAIN_ID } from '../../core/ConnectionStrategy.js'
@@ -15,7 +10,7 @@ import { OpenfortEthereumBridgeContext } from '../../ethereum/OpenfortEthereumBr
 import { useThemeFont } from '../../hooks/useGoogleFont.js'
 import { CoreOpenfortProvider } from '../../openfort/CoreOpenfortProvider.js'
 import type { useConnectCallbackProps } from '../../openfort/connectCallbackTypes.js'
-import type { CustomTheme, Languages, Mode, Theme } from '../../types.js'
+import type { CustomTheme, Languages, Mode, SDKOverrides, Theme } from '../../types.js'
 import { logger, setDebugLogsEnabled } from '../../utils/logger.js'
 import { buildChainFromConfig } from '../../utils/rpc.js'
 import { isFamily } from '../../utils/wallets.js'

--- a/packages/openfort-react/src/components/Openfort/context.ts
+++ b/packages/openfort-react/src/components/Openfort/context.ts
@@ -1,11 +1,11 @@
 'use client'
 
-import type { ChainTypeEnum, OAuthProvider, SDKOverrides, ThirdPartyAuthConfiguration } from '@openfort/openfort-js'
+import type { ChainTypeEnum, OAuthProvider, ThirdPartyAuthConfiguration } from '@openfort/openfort-js'
 import type React from 'react'
 import { createContext } from 'react'
 import type { Chain } from 'viem'
 import type { useConnectCallbackProps } from '../../openfort/connectCallbackTypes.js'
-import type { CustomTheme, Languages, Mode, Theme } from '../../types.js'
+import type { CustomTheme, Languages, Mode, SDKOverrides, Theme } from '../../types.js'
 import type {
   BuyFormState,
   DebugModeOptions,

--- a/packages/openfort-react/src/components/Pages/Buy/onrampRequest.ts
+++ b/packages/openfort-react/src/components/Pages/Buy/onrampRequest.ts
@@ -1,10 +1,5 @@
-import { SDKConfiguration } from '@openfort/openfort-js'
 import { ApiRequestError, UnsupportedOperationError } from '../../../errors/operation.js'
-
-const getBackendUrl = (): string => {
-  const sdkConfig = SDKConfiguration.getInstance()
-  return sdkConfig?.backendUrl || 'https://api.openfort.io'
-}
+import { getOpenfortBackendUrl } from '../../../openfort/core/client.js'
 
 type PostOnrampParameters = {
   /** Backend path, relative to the SDK's configured backend URL. */
@@ -28,7 +23,7 @@ type PostOnrampParameters = {
 export async function postOnramp<TResponse>(parameters: PostOnrampParameters): Promise<TResponse> {
   const { path, body, publishableKey, operation } = parameters
 
-  const response = await fetch(`${getBackendUrl()}${path}`, {
+  const response = await fetch(`${getOpenfortBackendUrl()}${path}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/openfort-react/src/hooks/openfort/useFunding.ts
+++ b/packages/openfort-react/src/hooks/openfort/useFunding.ts
@@ -1,12 +1,12 @@
 'use client'
 
-import { SDKConfiguration } from '@openfort/openfort-js'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useOpenfort } from '../../components/Openfort/useOpenfort.js'
 import { asOpenfortError, type OpenfortError } from '../../errors/base.js'
 import { FundingError, FundingNotConfiguredError } from '../../errors/funding.js'
 import { UnsupportedOperationError } from '../../errors/operation.js'
 import { useAuthTransitions } from '../../openfort/authTransitionContext.js'
+import { getOpenfortBackendUrl } from '../../openfort/core/client.js'
 import { useOpenfortCore } from '../../openfort/useOpenfort.js'
 import { getOrCreatePersistentOperation } from '../../shared/utils/persistentOperationRegistry.js'
 import { getTrustedFundingProviderUrl } from '../../utils/fundingProviderUrl.js'
@@ -155,7 +155,7 @@ export type UseFundingOptions = {
    * fetch adapter over `uiConfig.fundingBaseUrl`. */
   client?: FundingClient
   /**
-   * Resolve the base URL from the Openfort API backend (`SDKConfiguration.backendUrl`)
+   * Resolve the base URL from the configured Openfort API backend
    * instead of `uiConfig.fundingBaseUrl`. The CEX (Coinbase pay-link) rail is served
    * by the API, not the standalone funding service — `DepositCex` opts in.
    */
@@ -207,7 +207,7 @@ export function useFunding(options?: UseFundingOptions): UseFunding {
   // The funding JSON API defaults to the Openfort backend (api.openfort.io);
   // integrators can point the crypto rails at a custom service via
   // uiConfig.fundingBaseUrl. The CEX rail always uses the backend (Coinbase pay-link).
-  const backendUrl = SDKConfiguration.getInstance()?.backendUrl || 'https://api.openfort.io'
+  const backendUrl = getOpenfortBackendUrl()
   const baseUrl = options?.useBackendUrl ? backendUrl : uiConfig.fundingBaseUrl || backendUrl
   const injected = options?.client
   // Resolve the client, in order of preference:

--- a/packages/openfort-react/src/hooks/openfort/useFundingChains.ts
+++ b/packages/openfort-react/src/hooks/openfort/useFundingChains.ts
@@ -1,10 +1,10 @@
 'use client'
 
-import { SDKConfiguration } from '@openfort/openfort-js'
 import type { QueryKey } from '@tanstack/react-query'
 import { useCallback } from 'react'
 import { useOpenfort } from '../../components/Openfort/useOpenfort.js'
 import { ApiRequestError } from '../../errors/operation.js'
+import { getOpenfortBackendUrl } from '../../openfort/core/client.js'
 import { getOpenfortQueryInputScope, openfortKeys } from '../../query/queryKeys.js'
 import { useQuery } from '../../query/useQuery.js'
 import { getPublishableKeyEnvironment } from '../../utils/validation.js'
@@ -82,7 +82,7 @@ const EMPTY_CHAINS: FundingChain[] = []
 export function useFundingChains(): UseFundingChains {
   const { uiConfig, publishableKey } = useOpenfort()
   // Defaults to the SDK backend (api.openfort.io); override for a custom funding service.
-  const baseUrl = uiConfig.fundingBaseUrl || SDKConfiguration.getInstance()?.backendUrl || 'https://api.openfort.io'
+  const baseUrl = uiConfig.fundingBaseUrl || getOpenfortBackendUrl()
   const sourceChains = uiConfig.funding?.sourceChains ?? DEFAULT_SOURCE_CHAINS
   const sourceCurrencies = uiConfig.funding?.sourceCurrencies ?? DEFAULT_SOURCE_CURRENCIES
   // Match the rail host to the key environment: test keys (`pk_test_…`) list the

--- a/packages/openfort-react/src/openfort/core/client.ts
+++ b/packages/openfort-react/src/openfort/core/client.ts
@@ -1,5 +1,11 @@
 import { Openfort as OpenfortClient, type OpenfortSDKConfiguration } from '@openfort/openfort-js'
 
+const DEFAULT_BACKEND_URL = 'https://api.openfort.io'
+let backendUrl = DEFAULT_BACKEND_URL
+
+/** @internal */
+export const getOpenfortBackendUrl = (): string => backendUrl
+
 /**
  * Creates a new {@link OpenfortClient} instance.
  *
@@ -16,5 +22,6 @@ import { Openfort as OpenfortClient, type OpenfortSDKConfiguration } from '@open
  * ```
  */
 export function createOpenfortClient(config: OpenfortSDKConfiguration): OpenfortClient {
+  backendUrl = config.overrides?.backendUrl ?? DEFAULT_BACKEND_URL
   return new OpenfortClient(config)
 }

--- a/packages/openfort-react/src/solana/transfer.test.ts
+++ b/packages/openfort-react/src/solana/transfer.test.ts
@@ -1,7 +1,7 @@
-import { SDKConfiguration } from '@openfort/openfort-js'
 import { describe, expect, it, vi } from 'vitest'
 import { ValidationError } from '../errors/validation.js'
 import { WalletError } from '../errors/wallet.js'
+import { getOpenfortBackendUrl } from '../openfort/core/client.js'
 import {
   assertKoraInstructionsAreExpected,
   assertTransferableRecipient,
@@ -11,8 +11,8 @@ import {
   solToLamports,
 } from './transfer.js'
 
-vi.mock('@openfort/openfort-js', () => ({
-  SDKConfiguration: { getInstance: vi.fn(() => undefined) },
+vi.mock('../openfort/core/client.js', () => ({
+  getOpenfortBackendUrl: vi.fn(() => 'https://api.openfort.io'),
 }))
 
 describe('solToLamports', () => {
@@ -44,9 +44,7 @@ describe('koraRpcUrl', () => {
   })
 
   it('uses the configured SDK backend URL', () => {
-    vi.mocked(SDKConfiguration.getInstance).mockReturnValueOnce({
-      backendUrl: 'https://configured.example',
-    } as ReturnType<typeof SDKConfiguration.getInstance>)
+    vi.mocked(getOpenfortBackendUrl).mockReturnValueOnce('https://configured.example')
     expect(koraRpcUrl('mainnet-beta')).toBe('https://configured.example/rpc/solana/mainnet')
   })
 })

--- a/packages/openfort-react/src/solana/transfer.ts
+++ b/packages/openfort-react/src/solana/transfer.ts
@@ -12,12 +12,12 @@
  * runtime.
  */
 
-import { SDKConfiguration } from '@openfort/openfort-js'
 import type { Address, SignatureBytes, SignatureDictionary, TransactionSigner } from '@solana/kit'
 import { toError } from '../errors/base.js'
 import { ApiRequestError } from '../errors/operation.js'
 import { ValidationError } from '../errors/validation.js'
 import { WalletError } from '../errors/wallet.js'
+import { getOpenfortBackendUrl } from '../openfort/core/client.js'
 import { getDefaultSolanaRpcUrl } from '../utils/rpc.js'
 import type { OpenfortEmbeddedSolanaWalletProvider, SolanaCluster, SolanaCommitment } from './types.js'
 
@@ -351,7 +351,7 @@ export async function sendSplToken({
 /** @internal Exported for focused configuration tests; not part of a package entry point. */
 export function koraRpcUrl(cluster: SolanaCluster, backendUrl?: string): string {
   const segment = cluster === 'mainnet-beta' ? 'mainnet' : cluster
-  const baseUrl = backendUrl ?? SDKConfiguration.getInstance()?.backendUrl ?? 'https://api.openfort.io'
+  const baseUrl = backendUrl ?? getOpenfortBackendUrl()
   return `${baseUrl.replace(/\/$/, '')}/rpc/solana/${segment}`
 }
 

--- a/packages/openfort-react/src/types.ts
+++ b/packages/openfort-react/src/types.ts
@@ -1,3 +1,4 @@
+import type { OpenfortSDKConfiguration } from '@openfort/openfort-js'
 import type { OpenfortError } from './errors/index.js'
 import type { Languages as Lang } from './localizations/index.js'
 import type { CustomTheme } from './styles/customTheme.js'
@@ -39,5 +40,5 @@ export type OpenfortHookOptions<T = { error?: OpenfortError }> = {
 }
 
 // Re-export important types and enums from openfort-js
-export type { SDKOverrides } from '@openfort/openfort-js'
+export type SDKOverrides = NonNullable<OpenfortSDKConfiguration['overrides']>
 export { OAuthProvider, ThirdPartyOAuthProvider } from '@openfort/openfort-js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -928,8 +928,8 @@ importers:
   packages/openfort-react:
     dependencies:
       '@openfort/openfort-js':
-        specifier: ^1.6.0
-        version: 1.6.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: ^2.1.0
+        version: 2.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana-program/compute-budget':
         specifier: ^0.12.0 || ^0.13.0
         version: 0.13.0(@solana/kit@6.10.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
@@ -2282,8 +2282,13 @@ packages:
       better-auth: ^1.6.5
       zod: ^3.24.2 || ^4
 
-  '@openfort/openfort-js@1.6.0':
-    resolution: {integrity: sha512-aflScY3qadV+N2WbBijZ0eEqWexRsb43QEoCxPzv6KRDHZsxNYm9tcqd+0g26whZiylAVY4+8Znn43Q8sCX3FQ==}
+  '@openfort/openfort-js@2.1.0':
+    resolution: {integrity: sha512-L5DqKejbjJgxb5w7mlL6fUrz2k40X0etctQ6WAey4a09pWHZh4lQp+YXIJ09VPl00A3EysBKNB90VKSQhuOWng==}
+    peerDependencies:
+      typescript: ^5.9.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@openfort/openfort-node@0.10.8':
     resolution: {integrity: sha512-/cWf3GhSAb+4lo2Vt6pe7Y5ZuBgqtcapkFmbKJBGG3we8xlAlD/r6Sg5sbocvmLaJjHKgVnnt1D/pJGoPOFSWg==}
@@ -2316,6 +2321,9 @@ packages:
 
   '@openfort/shield-js@0.1.35':
     resolution: {integrity: sha512-S/v73xRnbgv5i47IRJ7cPWOnJ1bUTOJN+048Y8mJ+ya+iRJUXKTTqePaWApvfrVHHcKA+li8QGyDsRRDefLLVQ==}
+
+  '@openfort/shield-js@0.1.36':
+    resolution: {integrity: sha512-0vB5HvIxFr7IAzEFc7xr7FtiLvx6Zt+ByI48R8tywLb0+xp7ZAo/psB4sVz4aRyo+d+q5wW/5ulGP3mxkQeJyA==}
 
   '@openfort/shield-js@0.1.38':
     resolution: {integrity: sha512-vdQDHv8fY1s46rZ5Qd5RqdPZxOdeuya3QsFp5r5lLpyidqHOEktK3E1Novi/2UpK2oV9r3C+R68Ck3GZIhZXAQ==}
@@ -4930,6 +4938,17 @@ packages:
       zod:
         optional: true
 
+  abitype@1.3.0:
+    resolution: {integrity: sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==}
+    peerDependencies:
+      typescript: ^5.9.3
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -5157,8 +5176,8 @@ packages:
   blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
 
-  bn.js@5.2.3:
-    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
+  bn.js@5.2.5:
+    resolution: {integrity: sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==}
 
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
@@ -5598,8 +5617,8 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   es-set-tostringtag@2.1.0:
@@ -5882,10 +5901,6 @@ packages:
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
-
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -5899,8 +5914,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+  hono@4.12.33:
+    resolution: {integrity: sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -5947,8 +5962,8 @@ packages:
   idb-keyval@6.2.2:
     resolution: {integrity: sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==}
 
-  idb-keyval@6.2.5:
-    resolution: {integrity: sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==}
+  idb-keyval@6.3.0:
+    resolution: {integrity: sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==}
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -7892,6 +7907,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -8903,7 +8930,7 @@ snapshots:
     dependencies:
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/logger': 5.8.0
-      bn.js: 5.2.3
+      bn.js: 5.2.5
 
   '@ethersproject/bytes@5.8.0':
     dependencies:
@@ -8961,7 +8988,7 @@ snapshots:
       '@ethersproject/transactions': 5.8.0
       '@ethersproject/web': 5.8.0
       bech32: 1.1.4
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -8987,7 +9014,7 @@ snapshots:
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/logger': 5.8.0
       '@ethersproject/properties': 5.8.0
-      bn.js: 5.2.3
+      bn.js: 5.2.5
       elliptic: 6.6.1
       hash.js: 1.1.7
 
@@ -9504,7 +9531,7 @@ snapshots:
       better-auth: 1.6.25(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.1.8)
       zod: 4.3.6
 
-  '@openfort/openfort-js@1.6.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@openfort/openfort-js@2.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/bytes': 5.8.0
@@ -9512,13 +9539,14 @@ snapshots:
       '@ethersproject/keccak256': 5.8.0
       '@ethersproject/providers': 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@ethersproject/transactions': 5.8.0
-      '@openfort/shield-js': 0.1.38
+      '@openfort/shield-js': 0.1.36
       '@sentry/browser': 9.47.1
       '@sentry/core': 9.47.1
       axios: 1.19.0
       axios-retry: 4.5.0(axios@1.19.0)
       eventemitter3: 5.0.1
-      human-id: 4.1.3
+    optionalDependencies:
+      typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -9566,6 +9594,14 @@ snapshots:
       - zod
 
   '@openfort/shield-js@0.1.35':
+    dependencies:
+      axios: 1.19.0
+      axios-retry: 4.5.0(axios@1.19.0)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@openfort/shield-js@0.1.36':
     dependencies:
       axios: 1.19.0
       axios-retry: 4.5.0(axios@1.19.0)
@@ -11344,7 +11380,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/accounts@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11370,7 +11405,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/addresses@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11389,7 +11423,6 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/assertions@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11402,7 +11435,6 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/codecs-core@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11417,7 +11449,6 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/codecs-data-structures@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11433,7 +11464,6 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/codecs-numbers@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11449,7 +11479,6 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/codecs-strings@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11470,7 +11499,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/codecs@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11491,7 +11519,6 @@ snapshots:
       commander: 14.0.2
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/errors@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11503,7 +11530,6 @@ snapshots:
   '@solana/fast-stable-stringify@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/fast-stable-stringify@6.10.0(typescript@5.9.3)':
     optionalDependencies:
@@ -11519,7 +11545,6 @@ snapshots:
   '@solana/functional@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/functional@6.10.0(typescript@5.9.3)':
     optionalDependencies:
@@ -11537,7 +11562,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/instruction-plans@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11558,7 +11582,6 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/instructions@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11578,7 +11601,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/keys@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11636,7 +11658,6 @@ snapshots:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
-    optional: true
 
   '@solana/kit@6.10.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
@@ -11694,7 +11715,6 @@ snapshots:
   '@solana/nominal-types@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/nominal-types@6.10.0(typescript@5.9.3)':
     optionalDependencies:
@@ -11714,7 +11734,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/offchain-messages@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11742,7 +11761,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/options@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11759,7 +11777,6 @@ snapshots:
   '@solana/plugin-core@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/plugin-core@6.10.0(typescript@5.9.3)':
     optionalDependencies:
@@ -11803,7 +11820,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/programs@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11817,7 +11833,6 @@ snapshots:
   '@solana/promises@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/promises@6.10.0(typescript@5.9.3)':
     optionalDependencies:
@@ -11840,7 +11855,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/rpc-api@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11863,7 +11877,6 @@ snapshots:
   '@solana/rpc-parsed-types@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/rpc-parsed-types@6.10.0(typescript@5.9.3)':
     optionalDependencies:
@@ -11872,7 +11885,6 @@ snapshots:
   '@solana/rpc-spec-types@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/rpc-spec-types@6.10.0(typescript@5.9.3)':
     optionalDependencies:
@@ -11884,7 +11896,6 @@ snapshots:
       '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/rpc-spec@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11907,7 +11918,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/rpc-subscriptions-api@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11929,13 +11939,12 @@ snapshots:
       '@solana/functional': 5.5.1(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
       '@solana/subscribable': 5.5.1(typescript@5.9.3)
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-    optional: true
 
   '@solana/rpc-subscriptions-channel-websocket@6.10.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
@@ -11943,7 +11952,7 @@ snapshots:
       '@solana/functional': 6.10.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 6.10.0(typescript@5.9.3)
       '@solana/subscribable': 6.10.0(typescript@5.9.3)
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -11958,7 +11967,6 @@ snapshots:
       '@solana/subscribable': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/rpc-subscriptions-spec@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -11988,7 +11996,6 @@ snapshots:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
-    optional: true
 
   '@solana/rpc-subscriptions@6.10.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
@@ -12021,7 +12028,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/rpc-transformers@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -12043,7 +12049,6 @@ snapshots:
       undici-types: 7.24.6
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/rpc-transport-http@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -12066,7 +12071,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/rpc-types@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -12097,7 +12101,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/rpc@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -12130,7 +12133,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/signers@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -12153,7 +12155,6 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   '@solana/subscribable@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -12172,7 +12173,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/sysvars@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -12205,7 +12205,6 @@ snapshots:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
-    optional: true
 
   '@solana/transaction-confirmation@6.10.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
@@ -12241,7 +12240,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/transaction-messages@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -12277,7 +12275,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-    optional: true
 
   '@solana/transactions@6.10.0(typescript@5.9.3)':
     dependencies:
@@ -12317,7 +12314,7 @@ snapshots:
       '@types/phoenix': 1.6.7
       '@types/ws': 8.18.1
       tslib: 2.8.1
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -12709,7 +12706,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2(bufferutil@4.1.0)(utf-8-validate@6.0.6))(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2(bufferutil@4.1.0)(utf-8-validate@6.0.6))(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -12727,6 +12724,7 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.16(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+    optional: true
 
   '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -13139,7 +13137,7 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/safe-json': 1.0.2
       events: 3.3.0
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -13785,6 +13783,12 @@ snapshots:
       typescript: 5.9.3
       zod: 4.3.6
 
+  abitype@1.3.0(typescript@5.9.3)(zod@4.3.6):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.3.6
+    optional: true
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -13981,7 +13985,7 @@ snapshots:
 
   blakejs@1.2.1: {}
 
-  bn.js@5.2.3: {}
+  bn.js@5.2.5: {}
 
   body-parser@1.20.4:
     dependencies:
@@ -14173,8 +14177,7 @@ snapshots:
 
   commander@10.0.1: {}
 
-  commander@14.0.2:
-    optional: true
+  commander@14.0.2: {}
 
   commander@15.0.0: {}
 
@@ -14343,7 +14346,7 @@ snapshots:
 
   elliptic@6.6.1:
     dependencies:
-      bn.js: 5.2.3
+      bn.js: 5.2.5
       brorand: 1.1.0
       hash.js: 1.1.7
       hmac-drbg: 1.0.1
@@ -14387,7 +14390,7 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
-  es-object-atoms@1.1.1:
+  es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
 
@@ -14678,7 +14681,7 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
@@ -14691,7 +14694,7 @@ snapshots:
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   get-stream@6.0.1: {}
 
@@ -14767,10 +14770,6 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
 
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
-
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
@@ -14787,7 +14786,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.32:
+  hono@4.12.33:
     optional: true
 
   html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
@@ -14834,7 +14833,7 @@ snapshots:
 
   idb-keyval@6.2.2: {}
 
-  idb-keyval@6.2.5:
+  idb-keyval@6.3.0:
     optional: true
 
   idb@7.1.1: {}
@@ -14865,7 +14864,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-extglob@2.1.1: {}
 
@@ -15433,7 +15432,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.4(typescript@5.9.3)(zod@4.3.6)
+      abitype: 1.3.0(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -15603,8 +15602,8 @@ snapshots:
   porto@0.2.35(@tanstack/react-query@5.101.0(react@18.3.1))(@types/react@18.3.1)(@wagmi/core@3.5.0(@tanstack/query-core@5.99.2)(@types/react@18.3.1)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@3.6.16):
     dependencies:
       '@wagmi/core': 3.5.0(@tanstack/query-core@5.99.2)(@types/react@18.3.1)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
-      hono: 4.12.32
-      idb-keyval: 6.2.5
+      hono: 4.12.33
+      idb-keyval: 6.3.0
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.3.6)
       viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
@@ -15624,8 +15623,8 @@ snapshots:
   porto@0.2.35(@tanstack/react-query@5.101.0(react@18.3.1))(@types/react@18.3.1)(@wagmi/core@3.5.0(@tanstack/query-core@5.99.2)(@types/react@18.3.1)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6))(wagmi@3.6.16):
     dependencies:
       '@wagmi/core': 3.5.0(@tanstack/query-core@5.99.2)(@types/react@18.3.1)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6))
-      hono: 4.12.32
-      idb-keyval: 6.2.5
+      hono: 4.12.33
+      idb-keyval: 6.3.0
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.3.6)
       viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
@@ -16753,6 +16752,7 @@ snapshots:
       jsdom: 29.1.1(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - msw
+    optional: true
 
   vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2(bufferutil@4.1.0)(utf-8-validate@6.0.6))(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
@@ -16925,6 +16925,11 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6


### PR DESCRIPTION
## Summary

- update @openfort/openfort-js from 1.6.0 to 2.1.0
- adapt FortKit to the 2.1 public configuration types while preserving backend URL overrides
- add a patch changeset for @openfort/react

## Validation

- pnpm check
- pnpm check:types
- pnpm test:unit (820 tests)
- pnpm test:types (839 tests and type checks)
- pnpm test:cov
- pnpm knip --production
- publint and packed-tarball attw
- pnpm test:env
- pnpm size
- pnpm build:docs